### PR TITLE
feat: 지출 CRUD (API)

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/common/exception/advice/ApiExceptionAdvice.java
+++ b/src/main/java/com/hyerijang/dailypay/common/exception/advice/ApiExceptionAdvice.java
@@ -6,8 +6,10 @@ import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
+@RestControllerAdvice
 public class ApiExceptionAdvice {
 
     // API Exception 처리

--- a/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
+++ b/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
@@ -19,7 +19,8 @@ public enum ExceptionEnum {
 
     //expense
     NOT_EXIST_EXPENSE(HttpStatus.NOT_FOUND, "EXP001", "존재하지 않는 지출입니다."),
-    NOT_WRITER_OF_EXPENSE(HttpStatus.FORBIDDEN, "EX002", "조회하는 유저가 지출의 작성자가 아닙니다.");
+    NOT_WRITER_OF_EXPENSE(HttpStatus.FORBIDDEN, "EX002", "조회하는 유저가 지출의 작성자가 아닙니다."),
+    ALREADY_DELETED_EXPENSE(HttpStatus.FORBIDDEN, "EX003", "이미 삭제된 지출입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
+++ b/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
@@ -15,7 +15,11 @@ public enum ExceptionEnum {
 
     //user
     NOT_EXIST_USER(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 사용자입니다."),
-    ALREADY_EXIST_USER(HttpStatus.NOT_FOUND, "U002", "중복 회원입니다.");
+    ALREADY_EXIST_USER(HttpStatus.NOT_FOUND, "U002", "중복 회원입니다."),
+
+    //expense
+    NOT_EXIST_EXPENSE(HttpStatus.NOT_FOUND, "EXP001", "존재하지 않는 지출입니다."),
+    NOT_WRITER_OF_EXPENSE(HttpStatus.FORBIDDEN, "EX002", "조회하는 유저가 지출의 작성자가 아닙니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,12 +28,30 @@ public class ExpenseController {
 
     private final ExpenseService expenseService;
 
+    /**
+     * 새 지출 내역 (단건) 생성 API
+     */
+    @PostMapping
+    public ResponseEntity<Result> createExpense(
+        @RequestBody CreateExpenseRequest createExpenseRequest, Authentication authentication) {
+        ExpenseDto createdExpenseDto = expenseService.createExpense(createExpenseRequest,
+            authentication);
+        return ResponseEntity.ok().body(Result.builder().data(createdExpenseDto).build());
+
+    }
+
+    /**
+     * 유저의 지출 내역 (목록) 조회 API
+     */
     @GetMapping
     public ResponseEntity<Result> getAllExpenses() {
         List<ExpenseDto> userAllExpenses = expenseService.getUserAllExpenses();
         return ResponseEntity.ok().body(Result.builder().data(userAllExpenses).build());
     }
 
+    /***
+     * 유저의 지출 내역(단건) 조회 API
+     */
     @GetMapping("/{id}")
     public ResponseEntity<Result> getExpenseById(@PathVariable Long id) {
         ExpenseDto expenseDto = expenseService.getExpenseById(id);
@@ -44,14 +63,9 @@ public class ExpenseController {
         }
     }
 
-    @PostMapping
-    public ResponseEntity<Result> createExpense(
-        @RequestBody CreateExpenseRequest createExpenseRequest) {
-        ExpenseDto createdExpenseDto = expenseService.createExpense(createExpenseRequest);
-        return ResponseEntity.ok().body(Result.builder().data(createdExpenseDto).build());
-
-    }
-
+    /**
+     * 유저의 지출 내역(단건) 수정 API
+     */
     @PutMapping("/{id}")
     public ResponseEntity<Result> updateExpense(@PathVariable Long id,
         @RequestBody UpdateExpenseRequest updateExpenseRequest) {

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -82,6 +82,7 @@ public class ExpenseController {
     /***
      * 유저의 지출 내역(단건) 조회 API
      */
+    @ExeTimer
     @GetMapping("/{id}")
     public ResponseEntity<Result> getExpenseById(@PathVariable Long id,
         Authentication authentication) {
@@ -96,6 +97,7 @@ public class ExpenseController {
     /**
      * 유저의 지출 내역(단건) 수정 API
      */
+    @ExeTimer
     @PatchMapping("/{id}")
     public ResponseEntity<Result> updateExpense(@PathVariable Long id,
         @RequestBody UpdateExpenseRequest updateExpenseRequest, Authentication authentication) {

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -18,9 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -94,10 +94,11 @@ public class ExpenseController {
     /**
      * 유저의 지출 내역(단건) 수정 API
      */
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     public ResponseEntity<Result> updateExpense(@PathVariable Long id,
-        @RequestBody UpdateExpenseRequest updateExpenseRequest) {
-        ExpenseDto updatedExpenseDto = expenseService.updateExpense(id, updateExpenseRequest);
+        @RequestBody UpdateExpenseRequest updateExpenseRequest, Authentication authentication) {
+        ExpenseDto updatedExpenseDto = expenseService.updateExpense(id, updateExpenseRequest,
+            authentication);
         if (updatedExpenseDto != null) {
             return ResponseEntity.ok().body(Result.builder().data(updatedExpenseDto).build());
         }

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -2,6 +2,7 @@ package com.hyerijang.dailypay.expense.controller;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hyerijang.dailypay.budget.domain.Category;
+import com.hyerijang.dailypay.common.aop.ExeTimer;
 import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
 import com.hyerijang.dailypay.expense.dto.GetAllExpenseParam;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -104,6 +106,21 @@ public class ExpenseController {
         }
         return ResponseEntity.notFound().build();
     }
+
+    /**
+     * 유저의 지출 내역(단건) 삭제 API
+     */
+    @ExeTimer
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Result> deleteExpense(@PathVariable Long id,
+        Authentication authentication) {
+        ExpenseDto updatedExpenseDto = expenseService.deleteExpense(id, authentication);
+        if (updatedExpenseDto != null) {
+            return ResponseEntity.ok().body(Result.builder().data(updatedExpenseDto).build());
+        }
+        return ResponseEntity.notFound().build();
+    }
+
 
     @Getter
     @Builder

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -1,5 +1,6 @@
 package com.hyerijang.dailypay.expense.controller;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
 import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
@@ -29,7 +30,7 @@ public class ExpenseController {
     private final ExpenseService expenseService;
 
     /**
-     * 새 지출 내역 (단건) 생성 API
+     * 새 지출 내역 (단건) 생성 API <br> 본인의 지출 내역만 생성 가능
      */
     @PostMapping
     public ResponseEntity<Result> createExpense(
@@ -41,12 +42,13 @@ public class ExpenseController {
     }
 
     /**
-     * 유저의 지출 내역 (목록) 조회 API
+     * 유저의 지출 내역 (목록) 조회 API br> 본인의 지출 내역만 조회 가능
      */
     @GetMapping
-    public ResponseEntity<Result> getAllExpenses() {
-        List<ExpenseDto> userAllExpenses = expenseService.getUserAllExpenses();
-        return ResponseEntity.ok().body(Result.builder().data(userAllExpenses).build());
+    public ResponseEntity<Result> getAllExpenses(Authentication authentication) {
+        List<ExpenseDto> userAllExpenses = expenseService.getUserAllExpenses(authentication);
+        return ResponseEntity.ok()
+            .body(Result.builder().data(userAllExpenses).count(userAllExpenses.size()).build());
     }
 
     /***
@@ -57,7 +59,6 @@ public class ExpenseController {
         ExpenseDto expenseDto = expenseService.getExpenseById(id);
         if (expenseDto != null) {
             return ResponseEntity.ok().body(Result.builder().data(expenseDto).build());
-
         } else {
             return ResponseEntity.notFound().build();
         }
@@ -78,9 +79,10 @@ public class ExpenseController {
 
     @Getter
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     static class Result<T> {
 
-        private int count;
+        private Integer count;
         private T data; // 리스트의 값
     }
 

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -53,7 +53,6 @@ public class ExpenseController {
     public ResponseEntity<Result> getAllExpenses(GetAllExpenseParam getAllExpenseParam,
         Authentication authentication) {
 
-        log.info("---------------------------{}", getAllExpenseParam.end());
         //1. 기간 별 지출 내역 조회
         List<ExpenseDto> userAllExpenses = expenseService.getUserAllExpenses(getAllExpenseParam,
             authentication);
@@ -63,7 +62,8 @@ public class ExpenseController {
         Long totalExpense = userAllExpenses.stream()
             .filter(exDto -> !exDto.excludeFromTotal())
             .mapToLong(exDto -> exDto.amount()).sum();
-        //카테고리 별 지출 합계 (excludeFromTotal이 true인 경우 제외)
+
+        //3. 카테고리 별 지출 합계 (excludeFromTotal이 true인 경우 제외)
         Map<Category, BigDecimal> categoryWiseExpenseSum = userAllExpenses.stream()
             .filter(exDto -> !exDto.excludeFromTotal())
             .collect(Collectors.groupingBy(ExpenseDto::category,

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -122,6 +122,21 @@ public class ExpenseController {
     }
 
 
+    /**
+     * 유저의 지출 내역(단건)을 합계에서 제외하는 API
+     */
+    @ExeTimer
+    @PatchMapping("/{id}/exclude-total-sum")
+    public ResponseEntity<Result> excludeFromTotal(@PathVariable Long id,
+        Authentication authentication) {
+        ExpenseDto updatedExpenseDto = expenseService.excludeFromTotal(id, authentication);
+        if (updatedExpenseDto != null) {
+            return ResponseEntity.ok().body(Result.builder().data(updatedExpenseDto).build());
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+
     @Getter
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hyerijang.dailypay.budget.domain.Category;
 import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
-import com.hyerijang.dailypay.expense.dto.GetAllExpenseRequest;
+import com.hyerijang.dailypay.expense.dto.GetAllExpenseParam;
 import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
 import com.hyerijang.dailypay.expense.service.ExpenseService;
 import java.math.BigDecimal;
@@ -50,11 +50,12 @@ public class ExpenseController {
      * 유저의 지출 내역 (목록) 조회 API br> 본인의 지출 내역만 조회 가능
      */
     @GetMapping
-    public ResponseEntity<Result> getAllExpenses(
-        @RequestBody GetAllExpenseRequest getAllExpenseRequest, Authentication authentication) {
+    public ResponseEntity<Result> getAllExpenses(GetAllExpenseParam getAllExpenseParam,
+        Authentication authentication) {
 
+        log.info("---------------------------{}", getAllExpenseParam.end());
         //1. 기간 별 지출 내역 조회
-        List<ExpenseDto> userAllExpenses = expenseService.getUserAllExpenses(getAllExpenseRequest,
+        List<ExpenseDto> userAllExpenses = expenseService.getUserAllExpenses(getAllExpenseParam,
             authentication);
 
         //2. 지출 내역 토대로 지출 합계 , 카테고리 별 지출 합계 계산

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -3,6 +3,7 @@ package com.hyerijang.dailypay.expense.controller;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
+import com.hyerijang.dailypay.expense.dto.GetAllExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
 import com.hyerijang.dailypay.expense.service.ExpenseService;
 import java.util.List;
@@ -45,8 +46,10 @@ public class ExpenseController {
      * 유저의 지출 내역 (목록) 조회 API br> 본인의 지출 내역만 조회 가능
      */
     @GetMapping
-    public ResponseEntity<Result> getAllExpenses(Authentication authentication) {
-        List<ExpenseDto> userAllExpenses = expenseService.getUserAllExpenses(authentication);
+    public ResponseEntity<Result> getAllExpenses(
+        @RequestBody GetAllExpenseRequest getAllExpenseRequest, Authentication authentication) {
+        List<ExpenseDto> userAllExpenses = expenseService.getUserAllExpenses(getAllExpenseRequest,
+            authentication);
         return ResponseEntity.ok()
             .body(Result.builder().data(userAllExpenses).count(userAllExpenses.size()).build());
     }

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -81,8 +81,9 @@ public class ExpenseController {
      * 유저의 지출 내역(단건) 조회 API
      */
     @GetMapping("/{id}")
-    public ResponseEntity<Result> getExpenseById(@PathVariable Long id) {
-        ExpenseDto expenseDto = expenseService.getExpenseById(id);
+    public ResponseEntity<Result> getExpenseById(@PathVariable Long id,
+        Authentication authentication) {
+        ExpenseDto expenseDto = expenseService.getExpenseById(id, authentication);
         if (expenseDto != null) {
             return ResponseEntity.ok().body(Result.builder().data(expenseDto).build());
         } else {

--- a/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
@@ -84,4 +84,8 @@ public class Expense extends BaseTimeEntity {
     public void delete() {
         this.deleted = true;
     }
+
+    public void excludeFromTotal() {
+        this.excludeFromTotal = true;
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
@@ -70,4 +70,14 @@ public class Expense extends BaseTimeEntity {
         this.excludeFromTotal = excludeFromTotal;
         this.expenseDate = expenseDate;
     }
+
+    // === 비즈니스 메서드 ===//
+    public void update(Category category, Long amount, String memo, boolean excludeFromTotal,
+        LocalDateTime expenseDate) {
+        this.category = category;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeFromTotal = excludeFromTotal;
+        this.expenseDate = expenseDate;
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
@@ -80,4 +80,8 @@ public class Expense extends BaseTimeEntity {
         this.excludeFromTotal = excludeFromTotal;
         this.expenseDate = expenseDate;
     }
+
+    public void delete() {
+        this.deleted = true;
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
@@ -17,6 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -52,8 +53,21 @@ public class Expense extends BaseTimeEntity {
 
     boolean deleted = false;
 
-    // === 연관관계 메서드 ===//
+
+    // === Setter === //
     public void setUser(User user) {
         this.user = user;
+    }
+
+    // === 빌더 === //
+    @Builder
+    public Expense(User user, Category category, Long amount, String memo, boolean excludeFromTotal,
+        LocalDateTime expenseDate) {
+        this.user = user;
+        this.category = category;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeFromTotal = excludeFromTotal;
+        this.expenseDate = expenseDate;
     }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/domain/Expense.java
@@ -46,12 +46,12 @@ public class Expense extends BaseTimeEntity {
     private String memo;
 
     @Column(nullable = false)
-    private boolean excludeFromTotal;
+    private Boolean excludeFromTotal;
 
     @Column(nullable = false)
     private LocalDateTime expenseDate;
 
-    boolean deleted = false;
+    Boolean deleted = false;
 
 
     // === Setter === //
@@ -61,7 +61,7 @@ public class Expense extends BaseTimeEntity {
 
     // === 빌더 === //
     @Builder
-    public Expense(User user, Category category, Long amount, String memo, boolean excludeFromTotal,
+    public Expense(User user, Category category, Long amount, String memo, Boolean excludeFromTotal,
         LocalDateTime expenseDate) {
         this.user = user;
         this.category = category;
@@ -72,13 +72,23 @@ public class Expense extends BaseTimeEntity {
     }
 
     // === 비즈니스 메서드 ===//
-    public void update(Category category, Long amount, String memo, boolean excludeFromTotal,
+    public void update(Category category, Long amount, String memo, Boolean excludeFromTotal,
         LocalDateTime expenseDate) {
-        this.category = category;
-        this.amount = amount;
-        this.memo = memo;
-        this.excludeFromTotal = excludeFromTotal;
-        this.expenseDate = expenseDate;
+        if (category != null) {
+            this.category = category;
+        }
+        if (amount != null) {
+            this.amount = amount;
+        }
+        if (memo != null) {
+            this.memo = memo;
+        }
+        if (excludeFromTotal != null) {
+            this.excludeFromTotal = excludeFromTotal;
+        }
+        if (expenseDate != null) {
+            this.expenseDate = expenseDate;
+        }
     }
 
     public void delete() {

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/CreateExpenseRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/CreateExpenseRequest.java
@@ -1,6 +1,10 @@
 package com.hyerijang.dailypay.expense.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hyerijang.dailypay.budget.domain.Category;
+import com.hyerijang.dailypay.expense.domain.Expense;
+import com.hyerijang.dailypay.user.domain.User;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public record CreateExpenseRequest
@@ -9,7 +13,18 @@ public record CreateExpenseRequest
         Long amount,
         String memo,
         boolean excludeFromTotal,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime expenseDate
     ) {
 
+    public Expense toEntity(@NotNull User user) {
+        return Expense.builder()
+            .user(user)
+            .amount(this.amount)
+            .category(this.category)
+            .excludeFromTotal(this.excludeFromTotal)
+            .expenseDate(this.expenseDate)
+            .memo(this.memo)
+            .build();
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/CreateExpenseRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/CreateExpenseRequest.java
@@ -12,7 +12,7 @@ public record CreateExpenseRequest
         Category category,
         Long amount,
         String memo,
-        boolean excludeFromTotal,
+        Boolean excludeFromTotal,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime expenseDate
     ) {

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseDto.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseDto.java
@@ -1,5 +1,6 @@
 package com.hyerijang.dailypay.expense.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hyerijang.dailypay.budget.domain.Category;
 import com.hyerijang.dailypay.expense.domain.Expense;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ public record ExpenseDto(
     Long amount,
     String memo,
     Boolean excludeFromTotal,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime expenseDate
 ) {
 

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseDto.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseDto.java
@@ -3,6 +3,7 @@ package com.hyerijang.dailypay.expense.dto;
 import com.hyerijang.dailypay.budget.domain.Category;
 import com.hyerijang.dailypay.expense.domain.Expense;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -26,5 +27,9 @@ public record ExpenseDto(
             .excludeFromTotal(savedExpense.isExcludeFromTotal())
             .expenseDate(savedExpense.getExpenseDate())
             .build();
+    }
+
+    public static List<ExpenseDto> getExpenseDtoList(List<Expense> expenses) {
+        return expenses.stream().map((expense) -> ExpenseDto.of(expense)).toList();
     }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseDto.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseDto.java
@@ -1,8 +1,11 @@
 package com.hyerijang.dailypay.expense.dto;
 
 import com.hyerijang.dailypay.budget.domain.Category;
+import com.hyerijang.dailypay.expense.domain.Expense;
 import java.time.LocalDateTime;
+import lombok.Builder;
 
+@Builder
 public record ExpenseDto(
     Long id,
     Long userId,
@@ -13,4 +16,15 @@ public record ExpenseDto(
     LocalDateTime expenseDate
 ) {
 
+    public static ExpenseDto of(Expense savedExpense) {
+        return ExpenseDto.builder()
+            .id(savedExpense.getId())
+            .userId(savedExpense.getUser().getId())
+            .category(savedExpense.getCategory())
+            .amount(savedExpense.getAmount())
+            .memo(savedExpense.getMemo())
+            .excludeFromTotal(savedExpense.isExcludeFromTotal())
+            .expenseDate(savedExpense.getExpenseDate())
+            .build();
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseDto.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseDto.java
@@ -13,7 +13,7 @@ public record ExpenseDto(
     Category category,
     Long amount,
     String memo,
-    boolean excludeFromTotal,
+    Boolean excludeFromTotal,
     LocalDateTime expenseDate
 ) {
 
@@ -24,7 +24,7 @@ public record ExpenseDto(
             .category(savedExpense.getCategory())
             .amount(savedExpense.getAmount())
             .memo(savedExpense.getMemo())
-            .excludeFromTotal(savedExpense.isExcludeFromTotal())
+            .excludeFromTotal(savedExpense.getExcludeFromTotal())
             .expenseDate(savedExpense.getExpenseDate())
             .build();
     }

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseParam.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseParam.java
@@ -1,0 +1,12 @@
+package com.hyerijang.dailypay.expense.dto;
+
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+public record GetAllExpenseParam(
+    @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+    @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+
+}

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseRequest.java
@@ -1,0 +1,7 @@
+package com.hyerijang.dailypay.expense.dto;
+
+import java.time.LocalDate;
+
+public record GetAllExpenseRequest(LocalDate start, LocalDate end) {
+
+}

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseRequest.java
@@ -1,7 +1,0 @@
-package com.hyerijang.dailypay.expense.dto;
-
-import java.time.LocalDate;
-
-public record GetAllExpenseRequest(LocalDate start, LocalDate end) {
-
-}

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/UpdateExpenseRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/UpdateExpenseRequest.java
@@ -10,7 +10,7 @@ public record UpdateExpenseRequest
         Category category,
         Long amount,
         String memo,
-        boolean excludeFromTotal,
+        Boolean excludeFromTotal,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime expenseDate
     ) {
 

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/UpdateExpenseRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/UpdateExpenseRequest.java
@@ -1,16 +1,20 @@
 package com.hyerijang.dailypay.expense.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hyerijang.dailypay.budget.domain.Category;
+import com.hyerijang.dailypay.expense.domain.Expense;
 import java.time.LocalDateTime;
 
 public record UpdateExpenseRequest
     (
-        Long id,
         Category category,
         Long amount,
         String memo,
         boolean excludeFromTotal,
-        LocalDateTime expenseDate
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime expenseDate
     ) {
 
+    public void updateFoundWithRequest(Expense found) {
+        found.update(category, amount, memo, excludeFromTotal, expenseDate);
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepository.java
@@ -4,6 +4,7 @@ import com.hyerijang.dailypay.expense.domain.Expense;
 import com.hyerijang.dailypay.user.domain.User;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +13,6 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     List<Expense> findByExpenseDateBetweenAndUserAndDeletedIsFalse(LocalDateTime startDateTime,
         LocalDateTime endDateTime, User user);
+
+    Optional<Expense> findByIdAndDeletedIsFalse(Long id);
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepository.java
@@ -2,6 +2,7 @@ package com.hyerijang.dailypay.expense.repository;
 
 import com.hyerijang.dailypay.expense.domain.Expense;
 import com.hyerijang.dailypay.user.domain.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
-    List<Expense> findAllByUser(User user);
+    List<Expense> findByExpenseDateBetweenAndUserAndDeletedIsFalse(LocalDateTime startDateTime,
+        LocalDateTime endDateTime, User user);
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepository.java
@@ -1,10 +1,13 @@
 package com.hyerijang.dailypay.expense.repository;
 
 import com.hyerijang.dailypay.expense.domain.Expense;
+import com.hyerijang.dailypay.user.domain.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
+    List<Expense> findAllByUser(User user);
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -82,7 +82,7 @@ public class ExpenseService {
         }
 
         //삭제 유무 체크
-        if (found.isDeleted()) {
+        if (found.getDeleted()) {
             throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
         }
 
@@ -90,7 +90,7 @@ public class ExpenseService {
     }
 
 
-    boolean isNotExpenseWriter(User user, User writerOfExpense) {
+    Boolean isNotExpenseWriter(User user, User writerOfExpense) {
         return user != writerOfExpense;
     }
 
@@ -111,7 +111,7 @@ public class ExpenseService {
         }
 
         //삭제 유무 체크
-        if (found.isDeleted()) {
+        if (found.getDeleted()) {
             throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
         }
 
@@ -135,7 +135,7 @@ public class ExpenseService {
         }
 
         //삭제 유무 체크
-        if (found.isDeleted()) {
+        if (found.getDeleted()) {
             throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
         }
 
@@ -159,7 +159,7 @@ public class ExpenseService {
         }
 
         //삭제 유무 체크
-        if (found.isDeleted()) {
+        if (found.getDeleted()) {
             throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
         }
 

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -40,8 +40,13 @@ public class ExpenseService {
     /**
      * 유저의 지출 내역 (목록) 조회
      */
-    public List<ExpenseDto> getUserAllExpenses() {
-        return null;
+    public List<ExpenseDto> getUserAllExpenses(Authentication authentication) {
+        User user = userRepository.findByEmail(authentication.getName())
+            .orElseThrow(() -> new ApiException(
+                ExceptionEnum.NOT_EXIST_USER));
+
+        List<Expense> allByUser = expenseRepository.findAllByUser(user);
+        return ExpenseDto.getExpenseDtoList(allByUser);
     }
 
     /**

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -76,15 +76,7 @@ public class ExpenseService {
         Expense found = expenseRepository.findByIdAndDeletedIsFalse(id) // 삭제된 Expense 제외
             .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_EXPENSE));
 
-        //작성자인지 체크
-        if (isNotExpenseWriter(user, found.getUser())) {
-            throw new ApiException(ExceptionEnum.NOT_WRITER_OF_EXPENSE);
-        }
-
-        //삭제 유무 체크
-        if (found.getDeleted()) {
-            throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
-        }
+        validateFound(user, found);
 
         return ExpenseDto.of(found);
     }
@@ -105,15 +97,7 @@ public class ExpenseService {
         Expense found = expenseRepository.findById(id)
             .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_EXPENSE));
 
-        //작성자인지 체크
-        if (isNotExpenseWriter(user, found.getUser())) {
-            throw new ApiException(ExceptionEnum.NOT_WRITER_OF_EXPENSE);
-        }
-
-        //삭제 유무 체크
-        if (found.getDeleted()) {
-            throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
-        }
+        validateFound(user, found);
 
         //updateExpenseRequest의 내용으로 Expense found를 업데이트
         request.updateFoundWithRequest(found);
@@ -129,15 +113,8 @@ public class ExpenseService {
         User user = findUserByEmail(authentication);
         Expense found = expenseRepository.findById(id) // 삭제된 Expense 제외
             .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_EXPENSE));
-        //작성자인지 체크
-        if (isNotExpenseWriter(user, found.getUser())) {
-            throw new ApiException(ExceptionEnum.NOT_WRITER_OF_EXPENSE);
-        }
 
-        //삭제 유무 체크
-        if (found.getDeleted()) {
-            throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
-        }
+        validateFound(user, found);
 
         found.delete();
 
@@ -153,6 +130,18 @@ public class ExpenseService {
         User user = findUserByEmail(authentication);
         Expense found = expenseRepository.findById(id) // 삭제된 Expense 제외
             .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_EXPENSE));
+        validateFound(user, found);
+
+        found.excludeFromTotal();
+
+        return ExpenseDto.of(found);
+
+    }
+
+    /**
+     * user가 crud 가능한 found인지 검증
+     */
+    private void validateFound(User user, Expense found) {
         //작성자인지 체크
         if (isNotExpenseWriter(user, found.getUser())) {
             throw new ApiException(ExceptionEnum.NOT_WRITER_OF_EXPENSE);
@@ -162,10 +151,5 @@ public class ExpenseService {
         if (found.getDeleted()) {
             throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
         }
-
-        found.excludeFromTotal();
-
-        return ExpenseDto.of(found);
-
     }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -81,6 +81,11 @@ public class ExpenseService {
             throw new ApiException(ExceptionEnum.NOT_WRITER_OF_EXPENSE);
         }
 
+        //삭제 유무 체크
+        if (found.isDeleted()) {
+            throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
+        }
+
         return ExpenseDto.of(found);
     }
 
@@ -135,6 +140,30 @@ public class ExpenseService {
         }
 
         found.delete();
+
+        return ExpenseDto.of(found);
+
+    }
+
+    /**
+     * 유저의 지출 내역(단건)을 합계에서 제외
+     */
+    @Transactional
+    public ExpenseDto excludeFromTotal(Long id, Authentication authentication) {
+        User user = findUserByEmail(authentication);
+        Expense found = expenseRepository.findById(id) // 삭제된 Expense 제외
+            .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_EXPENSE));
+        //작성자인지 체크
+        if (isNotExpenseWriter(user, found.getUser())) {
+            throw new ApiException(ExceptionEnum.NOT_WRITER_OF_EXPENSE);
+        }
+
+        //삭제 유무 체크
+        if (found.isDeleted()) {
+            throw new ApiException(ExceptionEnum.ALREADY_DELETED_EXPENSE);
+        }
+
+        found.excludeFromTotal();
 
         return ExpenseDto.of(found);
 

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -1,11 +1,17 @@
 package com.hyerijang.dailypay.expense.service;
 
+import com.hyerijang.dailypay.common.exception.ApiException;
+import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
+import com.hyerijang.dailypay.expense.domain.Expense;
 import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
 import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
 import com.hyerijang.dailypay.expense.repository.ExpenseRepository;
+import com.hyerijang.dailypay.user.domain.User;
+import com.hyerijang.dailypay.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,21 +20,41 @@ public class ExpenseService {
     // TODO : 지출 서비스 구현
 
     private final ExpenseRepository expenseRepository;
+    private final UserRepository userRepository;
 
+    /**
+     * 새 지출 내역 (단건) 생성
+     */
+    public ExpenseDto createExpense(CreateExpenseRequest createExpenseRequest,
+        Authentication authentication) {
+
+        User user = userRepository.findByEmail(authentication.getName())
+            .orElseThrow(() -> new ApiException(
+                ExceptionEnum.NOT_EXIST_USER));
+
+        Expense savedExpense = expenseRepository.save(createExpenseRequest.toEntity(user));
+
+        return ExpenseDto.of(savedExpense);
+    }
+
+    /**
+     * 유저의 지출 내역 (목록) 조회
+     */
     public List<ExpenseDto> getUserAllExpenses() {
         return null;
     }
 
+    /**
+     * 유저의 지출 내역 (단건) 조회
+     */
     public ExpenseDto getExpenseById(Long id) {
         return null;
 
     }
 
-    public ExpenseDto createExpense(CreateExpenseRequest createExpenseRequest) {
-        return null;
-
-    }
-
+    /**
+     * 유저의 지출 내역(단건) 수정
+     */
     public ExpenseDto updateExpense(Long id, UpdateExpenseRequest updateExpenseRequest) {
         return null;
 

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -66,11 +66,25 @@ public class ExpenseService {
     }
 
     /**
-     * 유저의 지출 내역 (단건) 조회
+     * 유저의 지출 내역 (단건) 조회 , 삭제된 Expense는 제외
      */
-    public ExpenseDto getExpenseById(Long id) {
-        return null;
+    public ExpenseDto getExpenseById(Long id, Authentication authentication) {
+        User user = findUserByEmail(authentication);
+        Expense found = expenseRepository.findByIdAndDeletedIsFalse(id) // 삭제된 Expense 제외
+            .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_EXPENSE));
 
+        //작성자인지 체크
+        if (isNotExpenseWriter(user, found.getUser())) {
+            throw new ApiException(ExceptionEnum.NOT_WRITER_OF_EXPENSE);
+        }
+
+        return ExpenseDto.of(found);
+
+    }
+
+
+    boolean isNotExpenseWriter(User user, User writerOfExpense) {
+        return user != writerOfExpense;
     }
 
     /**

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -5,15 +5,18 @@ import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
 import com.hyerijang.dailypay.expense.domain.Expense;
 import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
+import com.hyerijang.dailypay.expense.dto.GetAllExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
 import com.hyerijang.dailypay.expense.repository.ExpenseRepository;
 import com.hyerijang.dailypay.user.domain.User;
 import com.hyerijang.dailypay.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ExpenseService {
@@ -40,13 +43,17 @@ public class ExpenseService {
     /**
      * 유저의 지출 내역 (목록) 조회
      */
-    public List<ExpenseDto> getUserAllExpenses(Authentication authentication) {
+    public List<ExpenseDto> getUserAllExpenses(GetAllExpenseRequest request,
+        Authentication authentication) {
         User user = userRepository.findByEmail(authentication.getName())
             .orElseThrow(() -> new ApiException(
                 ExceptionEnum.NOT_EXIST_USER));
 
-        List<Expense> allByUser = expenseRepository.findAllByUser(user);
-        return ExpenseDto.getExpenseDtoList(allByUser);
+        List<Expense> result = expenseRepository.findByExpenseDateBetweenAndUserAndDeletedIsFalse(
+            request.start().atStartOfDay(), request.end().atTime(23, 59, 59),
+            user); //시작일 0시 0분 0초 ~ 종료일의 23시 59분 59초
+        log.info("result = {}", result.size());
+        return ExpenseDto.getExpenseDtoList(result);
     }
 
     /**

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -5,7 +5,7 @@ import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
 import com.hyerijang.dailypay.expense.domain.Expense;
 import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
-import com.hyerijang.dailypay.expense.dto.GetAllExpenseRequest;
+import com.hyerijang.dailypay.expense.dto.GetAllExpenseParam;
 import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
 import com.hyerijang.dailypay.expense.repository.ExpenseRepository;
 import com.hyerijang.dailypay.user.domain.User;
@@ -43,7 +43,7 @@ public class ExpenseService {
     /**
      * 유저의 지출 내역 (목록) 조회
      */
-    public List<ExpenseDto> getUserAllExpenses(GetAllExpenseRequest request,
+    public List<ExpenseDto> getUserAllExpenses(GetAllExpenseParam request,
         Authentication authentication) {
         User user = userRepository.findByEmail(authentication.getName())
             .orElseThrow(() -> new ApiException(

--- a/src/main/java/com/hyerijang/dailypay/user/repository/UserRepository.java
+++ b/src/main/java/com/hyerijang/dailypay/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String username);
+
+
 }

--- a/src/test/java/com/hyerijang/dailypay/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/hyerijang/dailypay/expense/controller/ExpenseControllerTest.java
@@ -1,0 +1,121 @@
+package com.hyerijang.dailypay.expense.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyerijang.dailypay.budget.domain.Category;
+import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
+import com.hyerijang.dailypay.expense.dto.ExpenseDto;
+import com.hyerijang.dailypay.expense.service.ExpenseService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+
+@DisplayName("단위테스트 - ExpenseController")
+@ExtendWith(SpringExtension.class)
+class ExpenseControllerTest {
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private ExpenseService expenseService;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private ExpenseController expenseController;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(expenseController).build();
+    }
+
+
+    private ExpenseDto createSampleExpenseDto() {
+        return ExpenseDto.builder()
+            .id(1L)
+            .userId(1L)
+            .category(Category.FOOD)
+            .amount(50000L)
+            .memo("Lunch")
+            .excludeFromTotal(false)
+            .expenseDate(LocalDateTime.parse("2023-11-14T12:30:00"))
+            .build();
+    }
+
+    private List<ExpenseDto> createSampleExpenseDtoList() {
+        ExpenseDto expense1 = createSampleExpenseDto();
+        ExpenseDto expense2 = ExpenseDto.builder()
+            .id(2L)
+            .userId(1L)
+            .category(Category.UTILITIES)
+            .amount(40000L)
+            .memo("Utilities")
+            .excludeFromTotal(false)
+            .expenseDate(LocalDateTime.parse("2023-11-15T15:45:00"))
+            .build();
+        return Stream.of(expense1, expense2).collect(Collectors.toList());
+    }
+
+    @Test
+    @DisplayName("지출 내역 생성 API 테스트 ")
+    void createExpense() throws Exception {
+        // given
+        ExpenseDto createdExpenseDto = createSampleExpenseDto();
+
+        when(expenseService.createExpense(any(), any()))
+            .thenReturn(createdExpenseDto);
+
+        String json = """
+                {
+                  "category": "FOOD",
+                  "amount": 50000,
+                  "memo": "test_8ef6b77ce9cb",
+                  "excludeFromTotal": false,
+                  "expenseDate": "2023-11-14 12:30:00"
+                }
+            """;
+
+        // when
+        mockMvc.perform(post("/api/v1/expenses")
+                .content(json)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.data.amount").value(50000))
+            .andExpect(jsonPath("$.data.memo").value("Lunch"))
+            .andExpect(jsonPath("$.data.excludeFromTotal").value(false))
+            .andExpect(
+                jsonPath("$.data.expenseDate").value("2023-11-14 12:30:00"))
+            .andDo(print());
+        // then
+        verify(expenseService, times(1)).createExpense(any(CreateExpenseRequest.class),
+            any());
+
+    }
+    
+}

--- a/src/test/java/com/hyerijang/dailypay/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/hyerijang/dailypay/expense/controller/ExpenseControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -12,7 +13,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hyerijang.dailypay.budget.domain.Category;
-import com.hyerijang.dailypay.expense.dto.CreateExpenseRequest;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
 import com.hyerijang.dailypay.expense.service.ExpenseService;
 import java.time.LocalDateTime;
@@ -82,7 +82,7 @@ class ExpenseControllerTest {
     }
 
     @Test
-    @DisplayName("지출 내역 생성 API 테스트 ")
+    @DisplayName("성공 : 지출 내역 생성 API 테스트 ")
     void createExpense() throws Exception {
         // given
         ExpenseDto createdExpenseDto = createSampleExpenseDto();
@@ -113,9 +113,35 @@ class ExpenseControllerTest {
                 jsonPath("$.data.expenseDate").value("2023-11-14 12:30:00"))
             .andDo(print());
         // then
-        verify(expenseService, times(1)).createExpense(any(CreateExpenseRequest.class),
-            any());
+        verify(expenseService, times(1)).createExpense(any(), any());
 
     }
-    
+
+    @Test
+    @DisplayName("성공 : 지출 내역 조회 API 테스트 ")
+    void getAllExpenses() throws Exception {
+        // given
+        List<ExpenseDto> sampleExpenseDtoList = createSampleExpenseDtoList();
+
+        when(expenseService.getUserAllExpenses(any(), any()))
+            .thenReturn(sampleExpenseDtoList);
+
+        // when
+        mockMvc.perform(get("/api/v1/expenses")
+                .param("start", "2023-11-01")
+                .param("end", "2023-11-30")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.count").value(2))
+            .andExpect(jsonPath("$.data[0].amount").value(50000))
+            .andExpect(jsonPath("$.data[0].memo").value("Lunch"))
+            .andExpect(jsonPath("$.data[0].excludeFromTotal").value(false))
+            .andDo(print());
+        // then
+        verify(expenseService, times(1)).getUserAllExpenses(any(), any());
+
+    }
+    //TODO : 테스트 코드 보충
+
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

요구사항 C-2 지출 CRUD 기능을 구현하였습니다.

  ### 미구현된 요구사항
 읽기(목록)에 관한 아래 요구사항의 경우, JPQL, Spring Data Jpa 로는 쿼리를 구현하기 어려워 추후 **QueryDsl**로 동적 쿼리를 작성할 예정입니다.  (자세한 사항은 #31 참조)
 -  특정 `카테고리` 만 조회.
 -  `최소` , `최대` 금액으로 조회.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링


## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#31

