### PR TITLE
feat : [D-2] 오늘 지출 안내(API) 

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/budget/service/BudgetService.java
+++ b/src/main/java/com/hyerijang/dailypay/budget/service/BudgetService.java
@@ -150,6 +150,13 @@ public class BudgetService {
         return budgetList;
     }
 
+    /**
+     * 유저의 해당 년월 예산 을 DTO로 변환한 뒤 전부 반환
+     */
+    public List<BudgetDto> getBudgetDtoListOfAllCategoryListIn(YearMonth this_month, Long userId) {
+        return BudgetDto.getBudgetDetailList(getBudgetListOfAllCategoryListIn(this_month, userId));
+    }
+
     public List<BudgetDto> recommend(Long finalTodayExpenseProposal) {
         return recommend(new RecommendBudgetRequest(finalTodayExpenseProposal));
     }

--- a/src/main/java/com/hyerijang/dailypay/budget/service/BudgetService.java
+++ b/src/main/java/com/hyerijang/dailypay/budget/service/BudgetService.java
@@ -131,10 +131,6 @@ public class BudgetService {
 
     /**
      * 해당 년월의 예산 총액 가져옴
-     *
-     * @param yearMonth
-     * @param userId
-     * @return
      */
     public Long getTotalAmountOfBudgetIn(YearMonth yearMonth, Long userId) {
         return getBudgetListOfAllCategoryListIn(yearMonth, userId).stream()
@@ -142,7 +138,10 @@ public class BudgetService {
             .sum();
     }
 
-    public List<Budget> getBudgetListOfAllCategoryListIn(YearMonth this_month, Long userId) {
+    /**
+     * 유저의 해당 년월 예산 전부 반환
+     */
+    private List<Budget> getBudgetListOfAllCategoryListIn(YearMonth this_month, Long userId) {
         List<Budget> budgetList = budgetRepository.findByYearMonthAndUserId(this_month, userId);
 
         if (budgetList.size() == 0) {

--- a/src/main/java/com/hyerijang/dailypay/budget/service/BudgetService.java
+++ b/src/main/java/com/hyerijang/dailypay/budget/service/BudgetService.java
@@ -141,7 +141,8 @@ public class BudgetService {
     /**
      * 유저의 해당 년월 예산 전부 반환
      */
-    private List<Budget> getBudgetListOfAllCategoryListIn(YearMonth this_month, Long userId) {
+    private List<Budget> getBudgetListOfAllCategoryListIn(YearMonth this_month, Long userId)
+        throws ApiException {
         List<Budget> budgetList = budgetRepository.findByYearMonthAndUserId(this_month, userId);
 
         if (budgetList.size() == 0) {

--- a/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
+++ b/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
@@ -119,14 +119,18 @@ public class ConsultingController {
         // 2.이번 달 남은 예산 계산
         Long getAmountSpentThisMonth = consultingService.getAmountSpentThisMonth(
             authentication);
-        // 3. 카테고리 별 지출 통계
+        // 3. 이번달 카테고리 별 지출 통계
         Map<Category, BigDecimal> expenseStatisticsByCategory = consultingService.getExpenseStatisticsByCategory(
+            authentication);
+        // 4. 이번 달 카테고리 별 예산
+        List<BudgetDto> budgetsByCategoryInThisMonth = consultingService.getBudgetsByCategoryInThisMonth(
             authentication);
 
         // 로그
         log.info("이번 달 예산 = {}", budgetForThisMonth);
         log.info("이번달 지출 금액 = {}", getAmountSpentThisMonth);
         log.info("카테고리 별 지출 금액 = {}", expenseStatisticsByCategory);
+        log.info("이번 달 카테고리 별 예산 = {}", budgetsByCategoryInThisMonth);
 
         return ResponseEntity.ok().body(Result.builder()
             .budgetForThisMonth(budgetForThisMonth)

--- a/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
+++ b/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
@@ -38,11 +38,9 @@ public class ConsultingController {
         // 1.이번 달 남은 예산 계산
         Long budgetRemainingForThisMonth = consultingService.getBudgetRemainingForThisMonth(
             authentication);
-        log.info("이번달 남은 예산 = {}", budgetRemainingForThisMonth);
 
         // 2. 오늘 쓸 수 있는 금액 = (이번달 남은 예산) / (이번 달 남은 일 수)
         Long todayExpenseProposal = budgetRemainingForThisMonth / getRemainingDaysInMonth();
-        log.info("오늘 쓸 수 있는 금액 = {} , 일일 최소 소비금액 = {}", todayExpenseProposal, MIN_EXPENSE_OF_A_DAY);
 
         // 3. 지출 상황에 따라 응원멘트 변경
         String comments = setComment(todayExpenseProposal);
@@ -51,10 +49,12 @@ public class ConsultingController {
         todayExpenseProposal =
             todayExpenseProposal < MIN_EXPENSE_OF_A_DAY ? MIN_EXPENSE_OF_A_DAY
                 : todayExpenseProposal;
-        log.info("오늘 쓸 수 있는 금액 (최종) = {}", todayExpenseProposal);
-
         // 3.카테고리 별 제안액
         List<BudgetDto> proposalResponse = consultingService.getProposalInfo(todayExpenseProposal);
+
+        // 로그
+        log.info("이번달 남은 예산 = {}", budgetRemainingForThisMonth);
+        log.info("오늘 쓸 수 있는 금액 = {}", todayExpenseProposal);
         log.info("카테고리 별 제안액 = {}", proposalResponse);
         return ResponseEntity.ok().body(Result.builder()
             .budgetRemainingForThisMonth(budgetRemainingForThisMonth)
@@ -76,7 +76,7 @@ public class ConsultingController {
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
     static class Result<T> {
-        
+
         //[D-1]
         private Long budgetRemainingForThisMonth; // 이번 달 남은 예산
         private Long todayExpenseProposal; // 오늘 쓸 수 있는 금액
@@ -123,6 +123,7 @@ public class ConsultingController {
         Map<Category, BigDecimal> expenseStatisticsByCategory = consultingService.getExpenseStatisticsByCategory(
             authentication);
 
+        // 로그
         log.info("이번 달 예산 = {}", budgetForThisMonth);
         log.info("이번달 지출 금액 = {}", getAmountSpentThisMonth);
         log.info("카테고리 별 지출 금액 = {}", expenseStatisticsByCategory);

--- a/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
+++ b/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
@@ -128,12 +128,6 @@ public class ConsultingController {
         log.info("이번달 지출 금액 = {}", getAmountSpentThisMonth);
         log.info("카테고리 별 지출 금액 = {}", expenseStatisticsByCategory);
 
-        Result.builder()
-            .budgetForThisMonth(budgetForThisMonth)
-            .getAmountSpentThisMonth(getAmountSpentThisMonth)
-            .data(expenseStatisticsByCategory)
-            .build();
-
         return ResponseEntity.ok().body(Result.builder()
             .budgetForThisMonth(budgetForThisMonth)
             .getAmountSpentThisMonth(getAmountSpentThisMonth)

--- a/src/main/java/com/hyerijang/dailypay/consulting/service/ConsultingService.java
+++ b/src/main/java/com/hyerijang/dailypay/consulting/service/ConsultingService.java
@@ -70,7 +70,8 @@ public class ConsultingService {
      * 이번달 예산
      */
     private Long getBudgetThisMonth(Long userId) {
-        return budgetService.getTotalAmountOfBudgetIn(YearMonth.now(), userId);
+        return budgetService.getTotalAmountOfBudgetIn(YearMonth.now(),
+            userId);
     }
 
     /**

--- a/src/main/java/com/hyerijang/dailypay/consulting/service/ConsultingService.java
+++ b/src/main/java/com/hyerijang/dailypay/consulting/service/ConsultingService.java
@@ -115,4 +115,15 @@ public class ConsultingService {
                 ));
 
     }
+
+    /**
+     * 이번 달 카테고리 별 예산 dto 반환
+     */
+    public List<BudgetDto> getBudgetsByCategoryInThisMonth(Authentication authentication) {
+        User user = userRepository.findByEmail(authentication.getName())
+            .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
+
+        return budgetService.getBudgetDtoListOfAllCategoryListIn(YearMonth.now(), user.getId());
+
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -10,6 +10,7 @@ import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
 import com.hyerijang.dailypay.expense.repository.ExpenseRepository;
 import com.hyerijang.dailypay.user.domain.User;
 import com.hyerijang.dailypay.user.repository.UserRepository;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -156,10 +157,6 @@ public class ExpenseService {
 
     /**
      * 유저의 특정 년월 전체 지출
-     *
-     * @param yearMonth
-     * @param userId
-     * @return
      */
     public List<Expense> getAllUserExpensesIn(YearMonth yearMonth, Long userId) {
         User user = userRepository.findById(userId)
@@ -167,5 +164,18 @@ public class ExpenseService {
         return expenseRepository.findByExpenseDateBetweenAndUserAndDeletedIsFalse(
             yearMonth.atDay(1).atStartOfDay(), yearMonth.atEndOfMonth().atTime(23, 59, 59), user);
 
+    }
+
+    /**
+     * 유저의 오늘 전체 지출
+     */
+    public List<ExpenseDto> getAllUserExpensesIn(LocalDate localDate, Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
+        List<Expense> allUserExpensesIn = expenseRepository.findByExpenseDateBetweenAndUserAndDeletedIsFalse(
+            localDate.atTime(0, 0, 0), localDate.atTime(23, 59, 59), user);
+
+        //Dto로 변환
+        return ExpenseDto.getExpenseDtoList(allUserExpensesIn);
     }
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

[D-2] 오늘 지출 안내 (API)기능을 구현합니다. 본 서비스의 **메인 기능 [D]** 중 하나입니다. 

해당 API를 통해 유저는 아래 정보를 얻을 수 있습니다.

- `오늘 지출한 총액` : 오늘 소비한 총액
- `카테고리 별 통계` 
    - 일자 기준 오늘 적정 금액 (오늘 기준 사용했으면 적절했을 금액)
    - 일자 기준 오늘 지출 금액 (오늘 기준 사용한 금액)     
    -  위험도 : 카테고리별 적정 금액, 지출 금액의 차이를 위험도로 나타냄 (퍼센테이지)
        - ex) 오늘 사용하면 적당한 금액 10,000원/ 사용한 금액 20,000원 이면 200%

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링


## 📸 스크린샷

![image](https://github.com/hyerijang/daily-pay/assets/46921979/9f25e6c7-5090-4a60-a611-85cf300c8bbb)


## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#39 

