### PR TITLE
refactor : Token 엔티티에서 불필요한 Lombok 제거

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/token/Token.java
+++ b/src/main/java/com/hyerijang/dailypay/token/Token.java
@@ -25,7 +25,7 @@ import lombok.Setter;
 public class Token {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     public Long id;
 
     @Column(unique = true)

--- a/src/main/java/com/hyerijang/dailypay/token/Token.java
+++ b/src/main/java/com/hyerijang/dailypay/token/Token.java
@@ -6,15 +6,18 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -30,8 +33,9 @@ public class Token {
 
     public TokenType tokenType = TokenType.BEARER;
 
+    @Setter
     public boolean revoked = true;
-
+    @Setter
     public boolean expired = true;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/hyerijang/dailypay/token/Token.java
+++ b/src/main/java/com/hyerijang/dailypay/token/Token.java
@@ -19,8 +19,8 @@ import lombok.Setter;
 
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Token {
 


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

style : token에 불필요한 Lombok 어노테이션이 많이 붙어있어서 제거하였습니다. 
- @Data 제거
- 불필요한 Setter제거
- 접근제한자 access level  변경

refactor : Token id 생성전략을 IDENTITY로 변경하였습니다. (MySQL에서는 IDENTITY를 사용해야함)


## 📋 변경 사항

- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#11 

