### PR TITLE
feat : 통계용 더미데이터 초기화 로직 구현

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
+++ b/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
@@ -24,7 +24,7 @@ public enum ExceptionEnum {
     NOT_EXIST_EXPENSE(HttpStatus.NOT_FOUND, "EXP001", "존재하지 않는 지출입니다."),
     NOT_WRITER_OF_EXPENSE(HttpStatus.FORBIDDEN, "EX002", "조회하는 유저가 지출의 작성자가 아닙니다."),
     ALREADY_DELETED_EXPENSE(HttpStatus.FORBIDDEN, "EX003", "이미 삭제된 지출입니다."),
-    ;
+    NOT_EXIST_OTHER_USER(HttpStatus.BAD_REQUEST, "U003", "다른 유저가 존재하지 않습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -1,0 +1,23 @@
+package com.hyerijang.dailypay.statistics.controller;
+
+import com.hyerijang.dailypay.statistics.service.StatisticsDummyDataGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/statistics")
+public class StatisticsController {
+
+    private final StatisticsDummyDataGenerator dummyDataGenerator;
+
+    // FIXME : 해당 API 호출 시 더미데이터 생성됨, 운영 환경에서는 제거하거나 인가로 특정 권한 있는 사람만 실행할 수 있도록 수정
+    @PostMapping()
+    void generateDummy(Authentication authentication) {
+        dummyDataGenerator.generateDummy(authentication);
+    }
+
+}

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -15,7 +15,7 @@ public class StatisticsController {
     private final StatisticsDummyDataGenerator dummyDataGenerator;
 
     // FIXME : 해당 API 호출 시 더미데이터 생성됨, 운영 환경에서는 제거하거나 인가로 특정 권한 있는 사람만 실행할 수 있도록 수정
-    @PostMapping()
+    @PostMapping("/dummy-data")
     void generateDummy(Authentication authentication) {
         dummyDataGenerator.generateDummy(authentication);
     }

--- a/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsDummyDataGenerator.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsDummyDataGenerator.java
@@ -1,0 +1,200 @@
+package com.hyerijang.dailypay.statistics.service;
+
+import static java.lang.Math.min;
+
+import com.hyerijang.dailypay.budget.domain.Category;
+import com.hyerijang.dailypay.common.exception.ApiException;
+import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
+import com.hyerijang.dailypay.expense.domain.Expense;
+import com.hyerijang.dailypay.expense.repository.ExpenseRepository;
+import com.hyerijang.dailypay.user.domain.User;
+import com.hyerijang.dailypay.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StatisticsDummyDataGenerator {
+
+    private final ExpenseRepository expenseRepository;
+    private final UserRepository userRepository;
+
+    public void generateDummy(Authentication authentication) {
+        //유저 확인
+        log.info("유저 확인");
+        User user = userRepository.findByEmail(authentication.getName())
+            .orElseThrow(() -> new ApiException(
+                ExceptionEnum.NOT_EXIST_USER));
+        log.info("유저 확인");
+        log.debug("유저 확인");
+
+        generateDummy(user);
+    }
+
+
+    public void generateDummy(User user) {
+        final LocalDate TODAY = LocalDate.now();
+        final int SIZE = 100;
+
+        log.info("=== 더미 데이터 생성 시작 ===");
+        //1. 유저의 지난달 소비 데이터 100개 생성
+        createAndSaveExpenses(user, DateType.LAST_MONTH, SIZE); //유저, 지난달
+
+        //2. 유저의 7일전 (지난주, 같은요일) 소비 데이터 생성
+        createAndSaveExpenses(user, DateType.LAST_WEEK,
+            SIZE); //유저, 지난주
+
+        //3.다른 유저들의 오늘 소비 데이터 생성
+        User otherUser = userRepository.findAll().stream()
+            .filter(x -> x.getId() != user.getId())
+            .findAny()
+            .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_OTHER_USER));
+        createAndSaveExpenses(otherUser, DateType.TODAY,
+            SIZE); //다른유저, 오늘
+
+        log.info("=== 더미 데이터 생성 완료 ===");
+
+    }
+
+
+    /**
+     * 랜덤한 카테고리 가져오기
+     */
+    private static Category getRandomCategory() {
+        Category[] categories = Category.values();
+        int index = ThreadLocalRandom.current().nextInt(categories.length);
+        return categories[index];
+    }
+
+    /**
+     * 랜덤한 지출액 설정
+     */
+    private static Long getRandomAmount() {
+        return ThreadLocalRandom.current().nextLong(1, 30)
+            * 1000; // 1천~ 3만 랜덤 생성 (가독성을 위해 천원 단위로 끊음)
+    }
+
+
+    // === 지출 생성 및 저장 로직 ==
+    private void createAndSaveExpenses(User user, DateType lastMonth, int size) {
+        //생성
+        List<Expense> expenses = IntStream.range(0, size)
+            .mapToObj(
+                idx -> createRandomExpense(user, idx,
+                    generateRandomDateTime(lastMonth))) //지난달
+            .toList();
+
+        //저장
+        expenseRepository.saveAll(expenses);
+    }
+
+    /**
+     * 지출 1개 생성
+     */
+    private static Expense createRandomExpense(User user, Integer idx,
+        LocalDateTime localDateTime) {
+        Category category = getRandomCategory();
+        Long amount = getRandomAmount();
+        String description = "더미 데이터 " + idx;
+        boolean flag = false;
+        return new Expense(user, category, amount, description, flag, localDateTime);
+    }
+
+
+    // === 랜덤한 LocalDateTime 생성 로직 ===//
+    public enum DateType {
+        LAST_MONTH,
+        LAST_WEEK,
+        TODAY
+    }
+
+    private static LocalDateTime generateRandomDateTime(DateType dateType) {
+
+        switch (dateType) {
+            case LAST_MONTH:
+                return generateRandomDateTimeOfLastMonth();
+            case LAST_WEEK:
+                return generateRandomDateTimeOfLastWeek();
+            case TODAY:
+                return generateRandomDateTimeOfToday();
+            default:
+                throw new IllegalArgumentException("Invalid dateType: " + dateType);
+        }
+    }
+
+
+    /**
+     * 오늘이 a월 b일 일때, 지난 달 1일 ~ 지난 달 b 일까지의 LocalDateTime 을 랜덤하게 생성
+     */
+    private static LocalDateTime generateRandomDateTimeOfLastMonth() {
+        int year = LocalDateTime.now().getYear(); //year
+        int a = LocalDateTime.now().getMonth().getValue(); //month
+        int b = LocalDateTime.now().getDayOfMonth(); // day
+
+        //지난달의 마지막 일
+        int lastMonthLastDay = LocalDate.now().minusMonths(1)
+            .with(TemporalAdjusters.lastDayOfMonth()).getDayOfMonth();
+
+        //시작일 : 지난달 1일 , 종료일 : 지난달 b일
+        LocalDateTime startDateTime = LocalDateTime.of(year, Month.of(a - 1), 1, 0, 0);
+        LocalDateTime endDateTime = LocalDateTime.of(year, Month.of(a - 1),
+            min(b, lastMonthLastDay), 23, 59); // 일 : min(오늘 날짜,지난 달의 마지막 일)
+
+        return generateRandomDateTimeBetween(startDateTime, endDateTime);
+    }
+
+    /**
+     * 일주일 전 ~오늘까지의 LocalDateTime 을 랜덤하게 생성
+     */
+    private static LocalDateTime generateRandomDateTimeOfLastWeek() {
+        //오늘
+        LocalDateTime today = LocalDateTime.now();
+        //7일전
+        LocalDateTime sevenDaysAgo = today.minus(7, ChronoUnit.DAYS);
+        return generateRandomDateTimeBetween(sevenDaysAgo, today); // 7일전 ~ 오늘
+    }
+
+    /**
+     * 오늘 0시  ~ 현재 시각 까지의 LocalDateTime 을 랜덤하게 생성
+     */
+    private static LocalDateTime generateRandomDateTimeOfToday() {
+        //오늘 , 0시
+        LocalDateTime todayStart = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0);
+        //오늘, 현재 시각
+        LocalDateTime todayCurrent = LocalDateTime.now();
+        return generateRandomDateTimeBetween(todayStart, todayCurrent);
+    }
+
+
+    /**
+     * 시작일 ~ 종료일 사이의 랜덤 LocalDateTime 생성
+     */
+    private static LocalDateTime generateRandomDateTimeBetween(LocalDateTime startDateTime,
+        LocalDateTime endDateTime) {
+        long startEpochSecond = startDateTime.toEpochSecond(
+            ZoneOffset.UTC);//startDateTime의 Unix 시간(Epoch 시간)
+        long endEpochSecond = endDateTime.toEpochSecond(
+            ZoneOffset.UTC);//endDateTime의 Unix 시간(Epoch 시간)
+
+        //랜덤하게 생성
+        long randomEpochSecond = ThreadLocalRandom.current()
+            .nextLong(startEpochSecond, endEpochSecond);
+
+        return LocalDateTime.ofEpochSecond(randomEpochSecond, 0, ZoneOffset.UTC);
+    }
+
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약
사용자의 통계데이터 생성을 위해 Dummy 데이터를 생성합니다.

`POST` localhost:8000/api/v1/statistics/dummy-data

### 필요한 더미 데이터 종류

- 유저의 지난달 소비 데이터
- 유저의 7일전 (지난주, 같은요일) 소비 데이터
- 다른 유저의 오늘 소비 데이터

### 코드로 더미데이터 생성
SQL로 더미데이터 구현 시 날짜가 고정되므로 '오늘' 기준으로 통계 생성하는 저희 서비스와 맞지 않습니다. 따라서 동적 생성을 위해 코드로 생성하였습니다.


## 📋 변경 사항

- [x] 새로운 기능 추가

## 📸 스크린샷

![image](https://github.com/hyerijang/daily-pay/assets/46921979/d0e7de00-fd02-4c6d-b200-57239aaeeb05)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#46 #45
