### PR TITLE
refactor : 더미데이터 생성 API 개발 환경에서만 동작하도록 수정

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
+++ b/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
@@ -24,7 +24,10 @@ public enum ExceptionEnum {
     NOT_EXIST_EXPENSE(HttpStatus.NOT_FOUND, "EXP001", "존재하지 않는 지출입니다."),
     NOT_WRITER_OF_EXPENSE(HttpStatus.FORBIDDEN, "EX002", "조회하는 유저가 지출의 작성자가 아닙니다."),
     ALREADY_DELETED_EXPENSE(HttpStatus.FORBIDDEN, "EX003", "이미 삭제된 지출입니다."),
-    NOT_EXIST_OTHER_USER(HttpStatus.BAD_REQUEST, "U003", "다른 유저가 존재하지 않습니다.");
+
+    //statistics
+    NOT_EXIST_OTHER_USER(HttpStatus.NOT_FOUND, "S001", "통계 생성을 위한 다른 유저 데이터가 존재하지 않습니다."),
+    NOT_DEV_ENVIRONMENT(HttpStatus.FORBIDDEN, "S002 ", "운영 환경에서 실행할 수 없는 API입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -1,12 +1,19 @@
 package com.hyerijang.dailypay.statistics.controller;
 
+import com.hyerijang.dailypay.common.aop.ExeTimer;
+import com.hyerijang.dailypay.common.exception.ApiException;
+import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
 import com.hyerijang.dailypay.statistics.service.StatisticsDummyDataGenerator;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/statistics")
@@ -14,9 +21,21 @@ public class StatisticsController {
 
     private final StatisticsDummyDataGenerator dummyDataGenerator;
 
-    // FIXME : 해당 API 호출 시 더미데이터 생성됨, 운영 환경에서는 제거하거나 인가로 특정 권한 있는 사람만 실행할 수 있도록 수정
+    private final Environment environment;
+
+    // 개발 환경에서만 실행가능한 API, (application-dev.yml)
+    @ExeTimer
     @PostMapping("/dummy-data")
     void generateDummy(Authentication authentication) {
+
+        //개발 환경인지 체크
+        String[] activeProfiles = environment.getActiveProfiles();
+        boolean isNotDevActive = Arrays.stream(activeProfiles)
+            .noneMatch(profile -> profile.equals("dev"));
+        if (isNotDevActive) {
+            throw new ApiException(ExceptionEnum.NOT_DEV_ENVIRONMENT);
+        }
+
         dummyDataGenerator.generateDummy(authentication);
     }
 


### PR DESCRIPTION
운영환경에서 열려있으면 악용될 여지가 있어 개발 환경으로 호출을 제한합니다.

## 🚀 풀 리퀘스트 요약

한번 호출될 때마다 DB에 수백개의 데이터를 저장하는 만큼, 운영환경에서 열려있으면 악용될 여지가 있습니다. 따라서 개발 환경으로 호출을 제한합니다.

## 📋 변경 사항

- [x] 코드 리팩토링


## 📸 스크린샷

![image](https://github.com/hyerijang/daily-pay/assets/46921979/ba311cd2-e2bf-4be3-97e8-922f749fa2de)

#46 의 API는 운영환경에 'dev'가 포함되어 있을 때만 동작합니다.

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#46
