### PR TITLE
feat : [E-2] 지출 통계  API 구현

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
+++ b/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
@@ -27,7 +27,8 @@ public enum ExceptionEnum {
 
     //statistics
     NOT_EXIST_OTHER_USER(HttpStatus.NOT_FOUND, "S001", "통계 생성을 위한 다른 유저 데이터가 존재하지 않습니다."),
-    NOT_DEV_ENVIRONMENT(HttpStatus.FORBIDDEN, "S002 ", "운영 환경에서 실행할 수 없는 API입니다.");
+    NOT_DEV_ENVIRONMENT(HttpStatus.FORBIDDEN, "S002 ", "운영 환경에서 실행할 수 없는 API입니다."),
+    WRONG_EXPENSE_COMPARISON_CONDITION(HttpStatus.BAD_REQUEST, "S003", "지출 통계 쿼리 파라미터가 잘못 되었습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/hyerijang/dailypay/consulting/service/ConsultingService.java
+++ b/src/main/java/com/hyerijang/dailypay/consulting/service/ConsultingService.java
@@ -5,7 +5,6 @@ import com.hyerijang.dailypay.budget.dto.BudgetDto;
 import com.hyerijang.dailypay.budget.service.BudgetService;
 import com.hyerijang.dailypay.common.exception.ApiException;
 import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
-import com.hyerijang.dailypay.expense.domain.Expense;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
 import com.hyerijang.dailypay.expense.service.ExpenseService;
 import com.hyerijang.dailypay.user.domain.User;
@@ -48,12 +47,12 @@ public class ConsultingService {
      */
     private Long getAmountSpentThisMonth(Long userId) {
         //이번달 전체 지출
-        List<Expense> allUserExpensesInThinMonth = expenseService.getAllUserExpensesIn(
+        List<ExpenseDto> allUserExpensesInThinMonth = expenseService.getAllUserExpenseDtoListIn(
             YearMonth.now(),
             userId);
 
-        return allUserExpensesInThinMonth.stream().filter(expense -> !expense.getExcludeFromTotal())
-            .mapToLong(e -> e.getAmount()).sum();
+        return allUserExpensesInThinMonth.stream().filter(expense -> !expense.excludeFromTotal())
+            .mapToLong(e -> e.amount()).sum();
     }
 
     /**
@@ -97,13 +96,13 @@ public class ConsultingService {
     public List<ExpenseDto> getTodayExpenseInfo(Authentication authentication) {
         User user = userRepository.findByEmail(authentication.getName())
             .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
-        return expenseService.getAllUserExpensesIn(LocalDate.now(),
+        return expenseService.getAllUserExpenseDtoListIn(LocalDate.now(),
             user.getId());
     }
 
     public Map<Category, BigDecimal> getExpenseStatisticsByCategory(Authentication authentication) {
         List<ExpenseDto> todayExpenseInfo = getTodayExpenseInfo(authentication);
-        
+
         return todayExpenseInfo.stream()
             .filter(expenseDto -> !expenseDto.excludeFromTotal())
             .collect(

--- a/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepository.java
@@ -15,4 +15,7 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
         LocalDateTime endDateTime, User user);
 
     Optional<Expense> findByIdAndDeletedIsFalse(Long id);
+
+    List<Expense> findByExpenseDateBetweenAndDeletedIsFalse(LocalDateTime startDateTime,
+        LocalDateTime endDateTime);
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -196,4 +196,19 @@ public class ExpenseService {
         //Dto로 변환
         return ExpenseDto.getExpenseDtoList(allUserExpensesIn);
     }
+
+    public Long getAverageExpenseAmountOfToday() {
+
+        // FIXME : 오늘 일어났던 모든 소비를 DB에서 가져와서 stream으로 읽기 때문에 매우 비효율 적임. QueryDsl 적용 이후 수정요망.
+
+        //오늘 전체 유저들의 소비액 총합
+        List<Expense> allExpenseOfToday = expenseRepository.findByExpenseDateBetweenAndDeletedIsFalse(
+            LocalDateTime.now().withHour(0).withMinute(0).withSecond(0), // 오늘 0시 0분 0초부터
+            LocalDateTime.now());//현재 시각 까지
+        long sum = allExpenseOfToday.stream().mapToLong(x -> x.getAmount()).sum(); //오늘 전체 유저의 지출 총액
+        long numOfUserInToday = allExpenseOfToday.stream().map(Expense::getUser).distinct().toList()
+            .size(); //오늘 지출한 유저의 수
+
+        return sum / numOfUserInToday;
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/service/ExpenseService.java
@@ -11,6 +11,7 @@ import com.hyerijang.dailypay.expense.repository.ExpenseRepository;
 import com.hyerijang.dailypay.user.domain.User;
 import com.hyerijang.dailypay.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -158,7 +159,7 @@ public class ExpenseService {
     /**
      * 유저의 특정 년월 전체 지출
      */
-    public List<Expense> getAllUserExpensesIn(YearMonth yearMonth, Long userId) {
+    private List<Expense> getAllUserExpensesIn(YearMonth yearMonth, Long userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
         return expenseRepository.findByExpenseDateBetweenAndUserAndDeletedIsFalse(
@@ -166,14 +167,31 @@ public class ExpenseService {
 
     }
 
+    public List<ExpenseDto> getAllUserExpenseDtoListIn(YearMonth yearMonth, Long userId) {
+        List<Expense> expenses = getAllUserExpensesIn(yearMonth, userId);
+        return ExpenseDto.getExpenseDtoList(expenses);
+    }
+
     /**
      * 유저의 오늘 전체 지출
      */
-    public List<ExpenseDto> getAllUserExpensesIn(LocalDate localDate, Long userId) {
+    public List<ExpenseDto> getAllUserExpenseDtoListIn(LocalDate localDate, Long userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
         List<Expense> allUserExpensesIn = expenseRepository.findByExpenseDateBetweenAndUserAndDeletedIsFalse(
             localDate.atTime(0, 0, 0), localDate.atTime(23, 59, 59), user);
+
+        //Dto로 변환
+        return ExpenseDto.getExpenseDtoList(allUserExpensesIn);
+    }
+
+
+    public List<ExpenseDto> getAllUserExpenseDtoListIn(LocalDateTime start, LocalDateTime end,
+        Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
+        List<Expense> allUserExpensesIn = expenseRepository.findByExpenseDateBetweenAndUserAndDeletedIsFalse(
+            start, end, user);
 
         //Dto로 변환
         return ExpenseDto.getExpenseDtoList(allUserExpensesIn);

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -1,5 +1,6 @@
 package com.hyerijang.dailypay.statistics.controller;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hyerijang.dailypay.common.aop.ExeTimer;
 import com.hyerijang.dailypay.common.exception.ApiException;
 import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
@@ -38,18 +39,21 @@ public class StatisticsController {
     public ResponseEntity<Result> getExpenseComparison(@Param("condition") String condition,
         Authentication authentication) {
 
+        Result result;
         switch (condition) {
             case "last-month":
                 // (1)  지난 달 대비 총액 및 카테고리 별 소비율
-                Result result = Result.builder()
-                    .data(statisticsService.getExpenseComparisonLastMonth(authentication))
+                result = Result.builder()
+                    .expenseComparisonLastMonth(
+                        statisticsService.getExpenseComparisonLastMonth(authentication))
                     .build();
                 return ResponseEntity.ok().body(result);
             case "last-week":
                 // (2) 지난주 같은 요일 대비 소비율
-//                Result result = Result.builder()
-//                    .data(statisticsService.getLastWeekSameDayComparison(authentication)).build();
-//                return ResponseEntity.ok().body(result);
+                result = Result.builder()
+                    .lastWeekSameWeekDayComparison(
+                        statisticsService.getLastWeekSameWeekDayComparison(authentication)).build();
+                return ResponseEntity.ok().body(result);
             case "other-user":
                 // (3) 다른 유저 대비 소비율
 //                Result result = Result.builder().data(statisticsService.getExpenseComparisonWithOtherUser(authentication)).build();
@@ -61,10 +65,11 @@ public class StatisticsController {
 
     @Getter
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     static class Result<T> {
 
-        private int count;
-        private T data; // 리스트의 값
+        private T expenseComparisonLastMonth; // (1) 지난 달 대비 총액 및 카테고리 별 소비율
+        private Long lastWeekSameWeekDayComparison; // (2) 지난주 같은 요일 대비 소비율
     }
 
     // == 더미데이터 생성 == //

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -4,13 +4,18 @@ import com.hyerijang.dailypay.common.aop.ExeTimer;
 import com.hyerijang.dailypay.common.exception.ApiException;
 import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
 import com.hyerijang.dailypay.statistics.service.StatisticsDummyDataGenerator;
+import com.hyerijang.dailypay.statistics.service.StatisticsService;
 import java.util.Arrays;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -19,11 +24,56 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/statistics")
 public class StatisticsController {
 
-    private final StatisticsDummyDataGenerator dummyDataGenerator;
-
     private final Environment environment;
+    private final StatisticsDummyDataGenerator dummyDataGenerator;
+    private final StatisticsService statisticsService;
 
-    // 개발 환경에서만 실행가능한 API, (application-dev.yml)
+    // === 통계  API === //
+
+    /**
+     * 지난 달 대비 총액 및 카테고리 별 소비율을 반환
+     */
+    public ResponseEntity<Result> getExpenseComparison(@RequestParam String condition,
+        Authentication authentication) {
+
+        Result result;
+
+        switch (condition) {
+            case "lastMonth":
+                // 지난 달 대비 총액 및 카테고리 별 소비율
+                result = Result.builder()
+                    .data(statisticsService.getExpenseComparisonLastMonth(authentication))
+                    .build();
+                break;
+            case "lastWeek":
+                // 지난주 같은 요일 대비 소비율
+//                result = Result.builder().data(statisticsService.getLastWeekSameDayComparison(authentication)).build();
+                break;
+            case "otherUser":
+                // 다른 유저 대비 소비율
+//                result = Result.builder().data(statisticsService.getExpenseComparisonWithOtherUser(authentication)).build();
+                break;
+            default:
+                // 다른 경우에 대한 처리 (예: 유효하지 않은 조건)
+                throw new ApiException(ExceptionEnum.WRONG_EXPENSE_COMPARISON_CONDITION);
+        }
+        return ResponseEntity.ok().body(result);
+    }
+
+
+    @Getter
+    @Builder
+    static class Result<T> {
+
+        private int count;
+        private T data; // 리스트의 값
+    }
+
+    // == 더미데이터 생성 == //
+
+    /**
+     * 개발 환경에서만 실행가능한 API, (application-dev.yml)
+     */
     @ExeTimer
     @PostMapping("/dummy-data")
     void generateDummy(Authentication authentication) {

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -11,11 +11,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -31,33 +32,30 @@ public class StatisticsController {
     // === 통계  API === //
 
     /**
-     * 지난 달 대비 총액 및 카테고리 별 소비율을 반환
+     * 지난 달 대비 총액 및 카테고리 별 소비율(퍼센티지) 을 반환
      */
-    public ResponseEntity<Result> getExpenseComparison(@RequestParam String condition,
+    @GetMapping
+    public ResponseEntity<Result> getExpenseComparison(@Param("condition") String condition,
         Authentication authentication) {
 
-        Result result;
-
         switch (condition) {
-            case "lastMonth":
-                // 지난 달 대비 총액 및 카테고리 별 소비율
-                result = Result.builder()
+            case "last-month":
+                // (1)  지난 달 대비 총액 및 카테고리 별 소비율
+                Result result = Result.builder()
                     .data(statisticsService.getExpenseComparisonLastMonth(authentication))
                     .build();
-                break;
-            case "lastWeek":
-                // 지난주 같은 요일 대비 소비율
-//                result = Result.builder().data(statisticsService.getLastWeekSameDayComparison(authentication)).build();
-                break;
-            case "otherUser":
-                // 다른 유저 대비 소비율
-//                result = Result.builder().data(statisticsService.getExpenseComparisonWithOtherUser(authentication)).build();
-                break;
-            default:
-                // 다른 경우에 대한 처리 (예: 유효하지 않은 조건)
-                throw new ApiException(ExceptionEnum.WRONG_EXPENSE_COMPARISON_CONDITION);
+                return ResponseEntity.ok().body(result);
+            case "last-week":
+                // (2) 지난주 같은 요일 대비 소비율
+//                Result result = Result.builder()
+//                    .data(statisticsService.getLastWeekSameDayComparison(authentication)).build();
+//                return ResponseEntity.ok().body(result);
+            case "other-user":
+                // (3) 다른 유저 대비 소비율
+//                Result result = Result.builder().data(statisticsService.getExpenseComparisonWithOtherUser(authentication)).build();
+
         }
-        return ResponseEntity.ok().body(result);
+        throw new ApiException(ExceptionEnum.WRONG_EXPENSE_COMPARISON_CONDITION);
     }
 
 

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -56,8 +56,11 @@ public class StatisticsController {
                 return ResponseEntity.ok().body(result);
             case "other-user":
                 // (3) 다른 유저 대비 소비율
-//                Result result = Result.builder().data(statisticsService.getExpenseComparisonWithOtherUser(authentication)).build();
-
+                result = Result.builder()
+                    .expenseComparisonWithOtherUser(
+                        statisticsService.getExpenseComparisonWithOtherUser(authentication))
+                    .build();
+                return ResponseEntity.ok().body(result);
         }
         throw new ApiException(ExceptionEnum.WRONG_EXPENSE_COMPARISON_CONDITION);
     }
@@ -69,7 +72,8 @@ public class StatisticsController {
     static class Result<T> {
 
         private T expenseComparisonLastMonth; // (1) 지난 달 대비 총액 및 카테고리 별 소비율
-        private Long lastWeekSameWeekDayComparison; // (2) 지난주 같은 요일 대비 소비율
+        private Double lastWeekSameWeekDayComparison; // (2) 지난주 같은 요일 대비 소비율
+        private Double expenseComparisonWithOtherUser; // (3) 다른 유저 대비 소비율
     }
 
     // == 더미데이터 생성 == //

--- a/src/main/java/com/hyerijang/dailypay/statistics/dto/StatisticsDto.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/dto/StatisticsDto.java
@@ -4,6 +4,6 @@ import com.hyerijang.dailypay.budget.domain.Category;
 import java.util.Map;
 
 public record StatisticsDto(Long totalExpenseComparison,
-                            Map<Category, Long> categoryExpenseComparison) {
+                            Map<Category, Double> categoryExpenseComparison) {
 
 }

--- a/src/main/java/com/hyerijang/dailypay/statistics/dto/StatisticsDto.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/dto/StatisticsDto.java
@@ -1,0 +1,9 @@
+package com.hyerijang.dailypay.statistics.dto;
+
+import com.hyerijang.dailypay.budget.domain.Category;
+import java.util.Map;
+
+public record StatisticsDto(Long totalExpenseComparison,
+                            Map<Category, Long> categoryExpenseComparison) {
+
+}

--- a/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsDummyDataGenerator.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsDummyDataGenerator.java
@@ -146,6 +146,7 @@ public class StatisticsDummyDataGenerator {
         int b = LocalDateTime.now().getDayOfMonth(); // day
 
         //지난달의 마지막 일
+        // FIXME :  로직수정
         int lastMonthLastDay = LocalDate.now().minusMonths(1)
             .with(TemporalAdjusters.lastDayOfMonth()).getDayOfMonth();
 

--- a/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsService.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsService.java
@@ -1,10 +1,151 @@
 package com.hyerijang.dailypay.statistics.service;
 
+import static java.lang.Math.min;
+
+import com.hyerijang.dailypay.budget.domain.Category;
+import com.hyerijang.dailypay.common.exception.ApiException;
+import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
+import com.hyerijang.dailypay.expense.dto.ExpenseDto;
+import com.hyerijang.dailypay.expense.service.ExpenseService;
+import com.hyerijang.dailypay.statistics.dto.StatisticsDto;
+import com.hyerijang.dailypay.user.domain.User;
+import com.hyerijang.dailypay.user.repository.UserRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.YearMonth;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class StatisticsService {
+
+
+    private final UserRepository userRepository;
+    private final ExpenseService expenseService;
+
+    /**
+     * (1) 지난 달 대비 총액 및 카테고리 별 소비율
+     */
+    public StatisticsDto getExpenseComparisonLastMonth(Authentication authentication) {
+
+        User user = userRepository.findByEmail(authentication.getName())
+            .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
+
+        //1. 지난 달 대비 총액 소비율
+        Long totalExpenseComparison = getTotalExpenseComparisonTotalLastMonth(user);
+        //2. 지난 달 대비 카테고리 별 소비율
+        Map<Category, Long> categoryExpenseComparison = getCategoryExpenseComparisonLastMonth(user);
+
+        return new StatisticsDto(totalExpenseComparison, categoryExpenseComparison);
+    }
+
+
+    /**
+     * 지난 달 대비 총액 소비율
+     */
+    private Long getTotalExpenseComparisonTotalLastMonth(User user) {
+        //오늘이 yyyy 년 mm월 dd일 일때
+        int yyyy = LocalDateTime.now().getYear(); //year
+        int mm = LocalDateTime.now().getMonth().getValue(); //month
+        int dd = LocalDateTime.now().getDayOfMonth(); // day
+
+        // 1.지난달 1일 ~ b일 소비액
+        Long totalOfLastMonth = getTotal(yyyy, mm - 1, dd, user.getId()).stream()
+            .mapToLong(x -> x.amount()).sum();
+        // 2.이번 달 1일 ~ b일 소비액
+        Long totalOfThisMonth = getTotal(yyyy, mm, dd, user.getId()).stream()
+            .mapToLong(x -> x.amount()).sum();
+
+        double v = (double) totalOfThisMonth / totalOfLastMonth;
+        return Long.valueOf((long) v * 100);
+    }
+
+    // yy년 m월 1일~  m월 d일의 소비 내역 리턴
+    private List<ExpenseDto> getTotal(int yyyy, int mm, int dd, Long userId) {
+        //0월은 존재 하지 않으므로 yy-1년 12월로 변경
+        if (mm == 0) {
+            yyyy -= 1;
+            mm = 12;
+        }
+
+        //mm월의 일수 (e.g. 2월이면 28일, 3월은 31일)
+        int daysInMonth = YearMonth.of(yyyy, mm).lengthOfMonth();
+
+        //해당 월의 1일 , dd일을 시작과 끝으로 삼는다.
+        //- mm월 1일
+        LocalDateTime start = LocalDateTime.of(yyyy, Month.of(mm), 1, 0, 0);
+        //- mm월 dd일
+        LocalDateTime end = LocalDateTime.of(yyyy, Month.of(mm), min(dd, daysInMonth), 23, 59,
+            59); // min(주어진 날짜 ,이번 달의 마지막 일), e.g. 31이 주어졌는데, 2월이라 28일까지 밖에 없으면 28.
+
+        // start 부터 end 까지의 소비 내역 DTO로 반환
+        return expenseService.getAllUserExpenseDtoListIn(start, end, userId)
+            .stream()
+            .filter(expenseDto -> !expenseDto.excludeFromTotal())
+            .toList();
+    }
+
+    /**
+     * 지난 달 대비 카테고리 별 소비율
+     */
+    private Map<Category, Long> getCategoryExpenseComparisonLastMonth(User user) {
+        //1. 지난 달 카테고리 별 소비액
+        Map<Category, BigDecimal> categoryExpenseInLastMonth = getCategoryExpense(
+            expenseService.getAllUserExpenseDtoListIn(YearMonth.now().minusMonths(1),
+                user.getId())
+        );
+
+        //2. 이번 달 카테고리 별 소비액
+
+        Map<Category, BigDecimal> categoryExpenseInThisMonth = getCategoryExpense(
+            expenseService.getAllUserExpenseDtoListIn(YearMonth.now(),
+                user.getId())
+        );
+
+        //3. 지난달, 이번 달 비교
+
+        Map<Category, Long> comparison = new LinkedHashMap<>();
+
+        for (Category category : categoryExpenseInThisMonth.keySet()) { // 이번달 지출 카테고리
+            if (!categoryExpenseInLastMonth.containsKey(category)) {
+                //지난 달에는 해당 카테고리 소비 없었음
+                continue;
+            }
+
+            long lastMonthExpenseInThisCategory = categoryExpenseInLastMonth.get(category)
+                .longValue(); //해당 카테고리 지난달 소비액
+            long thisMonthExpenseInThisCategory = categoryExpenseInThisMonth.get(category)
+                .longValue(); //해당 카테고리 이번달 소비액
+
+            comparison.put(category, Long.valueOf(
+                (long) (((double) thisMonthExpenseInThisCategory
+                    / lastMonthExpenseInThisCategory) * 100)));
+        }
+
+        return comparison;
+
+    }
+
+
+    private static Map<Category, BigDecimal> getCategoryExpense(List<ExpenseDto> expenseDtoList) {
+        Map<Category, BigDecimal> collect = expenseDtoList.stream()
+            .filter(expenseDto -> !expenseDto.excludeFromTotal())
+            .collect(
+                Collectors.groupingBy(ExpenseDto::category,
+                    Collectors.reducing(BigDecimal.ZERO,
+                        exDto -> BigDecimal.valueOf(exDto.amount()), BigDecimal::add)
+                ));
+
+        return collect;
+    }
 
 }

--- a/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsService.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsService.java
@@ -1,0 +1,10 @@
+package com.hyerijang.dailypay.statistics.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class StatisticsService {
+
+}

--- a/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsService.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsService.java
@@ -11,6 +11,7 @@ import com.hyerijang.dailypay.statistics.dto.StatisticsDto;
 import com.hyerijang.dailypay.user.domain.User;
 import com.hyerijang.dailypay.user.repository.UserRepository;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.YearMonth;
@@ -66,7 +67,7 @@ public class StatisticsService {
             .mapToLong(x -> x.amount()).sum();
 
         double v = (double) totalOfThisMonth / totalOfLastMonth;
-        return Long.valueOf((long) v * 100);
+        return (long) v * 100;
     }
 
     // yy년 m월 1일~  m월 d일의 소비 내역 리턴
@@ -148,4 +149,23 @@ public class StatisticsService {
         return collect;
     }
 
+
+    /**
+     * (2) 지난주 같은 요일 대비 소비율
+     */
+    public Long getLastWeekSameWeekDayComparison(Authentication authentication) {
+        User user = userRepository.findByEmail(authentication.getName())
+            .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
+
+        //오늘 소비 총액
+        Long today = expenseService.getAllUserExpenseDtoListIn(LocalDate.now(), user.getId())
+            .stream().mapToLong(x -> x.amount()).sum();
+
+        // 지난주 같은 요일의 소비 총액
+        Long last = expenseService.getAllUserExpenseDtoListIn(LocalDate.now().minusDays(7),
+                user.getId())
+            .stream().mapToLong(x -> x.amount()).sum();
+
+        return (long) ((double) today / last) * 100;
+    }
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

사용자에게 통계 데이터를 제공합니다. 통계 조건은 쿼리 파라미터로 설정합니다.

### API URI

`Get` /api/v1/statistics?condition={통계 조건}

### {통계 조건} 
(1)  지난 달 대비 총액 및 카테고리 별 소비율 : last-month
(2) 지난주 같은 요일 대비 소비율: last-week
(3) 다른 유저 대비 소비율 : other-user


조건에 대한 상세 설명은 #47 참고

---

Spring data jpa의 조회 방식으로는 한계가 있어서,  **DB에서 조회하고 straem으로 필터링**하는 방식을 사용했습니다.  

특히 (3)에서, Jpa로 전체 유저의 오늘 소비 기록을 가져오는 아주 비효율적인 로직이 포함되어있습니다! 해당 로직은 **유저 수가 많아지면 성능에 큰 문제**를 일으키리라고 생각됩니다. **추후 QueryDsl 적용 이후 동적 쿼리 방식으로 리펙토링할 예정**입니다.😂 



## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링

## 📸 스크린샷

![image](https://github.com/hyerijang/daily-pay/assets/46921979/c422acbc-7e47-4c50-8cd8-6e490fa348f7)

## 📌 체크리스트

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#47 
