### PR TITLE
fix : [E-1-2] 통계 생성시 분모가 0인 경우 infinite를 출력하는 문제

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
+++ b/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
@@ -28,7 +28,9 @@ public enum ExceptionEnum {
     //statistics
     NOT_EXIST_OTHER_USER(HttpStatus.NOT_FOUND, "S001", "통계 생성을 위한 다른 유저 데이터가 존재하지 않습니다."),
     NOT_DEV_ENVIRONMENT(HttpStatus.FORBIDDEN, "S002 ", "운영 환경에서 실행할 수 없는 API입니다."),
-    WRONG_EXPENSE_COMPARISON_CONDITION(HttpStatus.BAD_REQUEST, "S003", "지출 통계 쿼리 파라미터가 잘못 되었습니다.");
+    WRONG_EXPENSE_COMPARISON_CONDITION(HttpStatus.BAD_REQUEST, "S003",
+        "지출 통계 쿼리 파라미터가 잘못 되었습니다."),
+    NOT_EXIST_LAST_WEEK_EXPENSE(HttpStatus.FORBIDDEN, "S004", "유저의 지난 주 같은 요일에 소비 내역이 없습니다. ");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsService.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/service/StatisticsService.java
@@ -158,14 +158,17 @@ public class StatisticsService {
     public Double getLastWeekSameWeekDayComparison(Authentication authentication) {
         User user = userRepository.findByEmail(authentication.getName())
             .orElseThrow(() -> new ApiException(ExceptionEnum.NOT_EXIST_USER));
-
-        //오늘 소비 총액
-        Long today = expenseService.getAllUserExpenseDtoListIn(LocalDate.now(), user.getId())
-            .stream().mapToLong(x -> x.amount()).sum();
-
         // 지난주 같은 요일의 소비 총액
         Long last = expenseService.getAllUserExpenseDtoListIn(LocalDate.now().minusDays(7),
                 user.getId())
+            .stream().mapToLong(x -> x.amount()).sum();
+
+        if (last == 0) {
+            throw new ApiException(ExceptionEnum.NOT_EXIST_LAST_WEEK_EXPENSE);
+        }
+
+        //오늘 소비 총액
+        Long today = expenseService.getAllUserExpenseDtoListIn(LocalDate.now(), user.getId())
             .stream().mapToLong(x -> x.amount()).sum();
 
         return ((double) today / last) * 100;


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

해당 문제는 다음과 같은 상황에서 발생합니다.

- (2) 지난주 같은 요일 대비 소비율 : 지난주 같은 요일에 유저 자신의 소비 내역이 없음

(1), (3)의 경우 분모가 0이 되기 전 다른 예외가 발생하기 때문에 해당 메서드에서만 예외 처리해주었습니다.

## 📋 변경 사항

- [x] 버그 수정


## 📸 스크린샷

### 변경전
![image](https://github.com/hyerijang/daily-pay/assets/46921979/bdd83bf2-0d12-4237-bd28-514f8ee42fe6)

### 변경후
![image](https://github.com/hyerijang/daily-pay/assets/46921979/88bd1fc3-c693-437a-862c-37b556261dea)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#52 #47

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)
