### PR TITLE
feat : API 문서 Swagger로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
     implementation 'io.jsonwebtoken:jjwt:0.12.3'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
 }
 

--- a/src/main/java/com/hyerijang/dailypay/auth/AuthenticationController.java
+++ b/src/main/java/com/hyerijang/dailypay/auth/AuthenticationController.java
@@ -1,5 +1,10 @@
 package com.hyerijang.dailypay.auth;
 
+import com.hyerijang.dailypay.common.aop.ExeTimer;
+import com.hyerijang.dailypay.common.exception.ApiException;
+import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -10,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "auth", description = "인증 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -17,6 +23,8 @@ public class AuthenticationController {
 
     private final AuthenticationService service;
 
+    @ExeTimer
+    @Operation(summary = "회원가입", description = "회원가입")
     @PostMapping("/register")
     public ResponseEntity<AuthenticationResponse> register(
         @RequestBody RegisterRequest request
@@ -24,6 +32,7 @@ public class AuthenticationController {
         return ResponseEntity.ok(service.register(request));
     }
 
+    @Operation(summary = "로그인", description = "로그인")
     @PostMapping("/login")
     public ResponseEntity<AuthenticationResponse> authenticate(
         @RequestBody AuthenticationRequest request
@@ -31,6 +40,7 @@ public class AuthenticationController {
         return ResponseEntity.ok(service.authenticate(request));
     }
 
+    @Operation(summary = "Access token 갱신", description = "refresh token을 필요로 합니다.")
     @PostMapping("/refresh")
     public void refreshAccessToken(
         HttpServletRequest request,
@@ -39,5 +49,12 @@ public class AuthenticationController {
         service.refreshToken(request, response);
     }
 
+    @Operation(summary = "로그아웃")
 
+    @PostMapping("/logout")
+    public void logout() {
+        //SpringSecurity에서 로그아웃 처리해야함. 여기까지 넘어오면 X
+        //SecurityConfiguration 참조
+        throw new ApiException(ExceptionEnum.LOGOUT_EXCEPTION);
+    }
 }

--- a/src/main/java/com/hyerijang/dailypay/auth/AuthenticationRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/auth/AuthenticationRequest.java
@@ -1,5 +1,12 @@
 package com.hyerijang.dailypay.auth;
 
-public record AuthenticationRequest(String email, String password) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "인증(로그인) 요청")
+public record AuthenticationRequest(
+    @Schema(description = "이메일")
+    String email,
+    @Schema(description = "비밀번호")
+    String password) {
 
 }

--- a/src/main/java/com/hyerijang/dailypay/auth/AuthenticationResponse.java
+++ b/src/main/java/com/hyerijang/dailypay/auth/AuthenticationResponse.java
@@ -1,8 +1,13 @@
 package com.hyerijang.dailypay.auth;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record AuthenticationResponse(@JsonProperty("access_token") String accessToken,
-                                     @JsonProperty("refresh_token") String refreshToken) {
+@Schema(description = "인증(로그인) 응답")
+public record AuthenticationResponse(
+    @Schema(description = "access 토큰")
+    @JsonProperty("access_token") String accessToken,
+    @Schema(description = "refresh 토큰")
+    @JsonProperty("refresh_token") String refreshToken) {
 
 }

--- a/src/main/java/com/hyerijang/dailypay/auth/RegisterRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/auth/RegisterRequest.java
@@ -1,11 +1,15 @@
 package com.hyerijang.dailypay.auth;
 
 import com.hyerijang.dailypay.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 
+@Schema(description = "회원 가입 요청")
 public record RegisterRequest(
+    @Schema(description = "이메일")
     @NotBlank String email,
+    @Schema(description = "비밀번호")
     @NotBlank String password
 ) {
 

--- a/src/main/java/com/hyerijang/dailypay/budget/controller/BudgetController.java
+++ b/src/main/java/com/hyerijang/dailypay/budget/controller/BudgetController.java
@@ -8,6 +8,8 @@ import com.hyerijang.dailypay.budget.dto.RecommendBudgetRequest;
 import com.hyerijang.dailypay.budget.repository.BudgetRepository;
 import com.hyerijang.dailypay.budget.service.BudgetService;
 import com.hyerijang.dailypay.common.aop.ExeTimer;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "budgets", description = "예산 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/budgets")
@@ -30,10 +33,11 @@ public class BudgetController {
     private final BudgetService budgetService;
     private final BudgetRepository budgetRepository;
 
+    @ExeTimer
+    @Operation(summary = "카테고리 조회", description = "카테고리 조회")
     @GetMapping("/categories")
     ResponseEntity<Result> getBudgetCategories() {
         List<CategoryDto> categoryDtoList = budgetService.getCategories();
-
         return ResponseEntity.ok()
             .body(Result.builder()
                 .count(categoryDtoList.size())
@@ -48,11 +52,9 @@ public class BudgetController {
         private T data; // 리스트의 값
     }
 
-    /**
-     * 예산 설정 및 업데이트 (금액만 변경 가능)
-     */
 
     @ExeTimer
+    @Operation(summary = "예산 설정 및 업데이트", description = "예산 설정 및 업데이트 (금액만 변경 가능)")
     @PostMapping
     ResponseEntity<Result> updateBudgets(@RequestBody CreateBudgetListRequest request,
         Authentication authentication) {
@@ -61,10 +63,8 @@ public class BudgetController {
         return ResponseEntity.ok().body(result);
     }
 
-    /**
-     * 예산 설계(추천) API
-     */
     @ExeTimer
+    @Operation(summary = "예산 추천", description = "예산 추천")
     @GetMapping
     ResponseEntity<Result> recommendBudgets(@RequestBody RecommendBudgetRequest request,
         Authentication authentication) {

--- a/src/main/java/com/hyerijang/dailypay/budget/dto/BudgetDto.java
+++ b/src/main/java/com/hyerijang/dailypay/budget/dto/BudgetDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.YearMonthDeserializer;
 import com.hyerijang.dailypay.budget.domain.Budget;
 import com.hyerijang.dailypay.budget.domain.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,8 +16,11 @@ import lombok.Builder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record BudgetDto(Long id,
                         @JsonDeserialize(using = YearMonthDeserializer.class)
+                        @Schema(description = "예산 년월")
                         YearMonth yearMonth,
+                        @Schema(description = "카테고리")
                         Category category,
+                        @Schema(description = "카테고리 별 남은 예산액")
                         Long amount) {
 
     public static List<BudgetDto> getBudgetDetailList(List<Budget> budgets) {
@@ -42,7 +46,10 @@ public record BudgetDto(Long id,
         return budgetDtoList;
     }
 
-    private static BudgetDto createBudgetDetail(Long leftAmountOfUser, Category category,
+
+    private static BudgetDto createBudgetDetail(
+        Long leftAmountOfUser,
+        Category category,
         Integer ratio) {
         return BudgetDto
             .builder()

--- a/src/main/java/com/hyerijang/dailypay/budget/dto/CreateBudgetListRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/budget/dto/CreateBudgetListRequest.java
@@ -2,21 +2,27 @@ package com.hyerijang.dailypay.budget.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hyerijang.dailypay.budget.domain.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.Getter;
 
+@Schema(description = "예산 생성 및 업데이트 요청")
 @Getter
 public class CreateBudgetListRequest {
 
     private List<CreateBudgetDetail> data;
+    @Schema(description = "예산 년월")
     @JsonFormat(pattern = "yyyy-MM") //형식 : yyyy-MM
     private YearMonth yearMonth;
 
+    @Schema(description = "카테고리 및 카테고리 별 남은 예산액")
     @Getter
     public static class CreateBudgetDetail {
 
+        @Schema(description = "카테고리")
         private Category category;
+        @Schema(description = "카테고리 별 남은 예산액")
         private Long amount;
     }
 

--- a/src/main/java/com/hyerijang/dailypay/budget/dto/RecommendBudgetRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/budget/dto/RecommendBudgetRequest.java
@@ -1,5 +1,11 @@
 package com.hyerijang.dailypay.budget.dto;
 
-public record RecommendBudgetRequest(Long userBudgetTotalAmount) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "예산 추천 요청")
+public record RecommendBudgetRequest(
+    @Schema(description = "유저의 예산 총액")
+    Long userBudgetTotalAmount
+) {
 
 }

--- a/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
+++ b/src/main/java/com/hyerijang/dailypay/common/exception/response/ExceptionEnum.java
@@ -12,6 +12,8 @@ public enum ExceptionEnum {
     //auth
     ACCESS_DENIED_EXCEPTION(HttpStatus.UNAUTHORIZED, "A002", "인증이 필요합니다"),
     WRONG_REQUEST(HttpStatus.BAD_REQUEST, "A003", "잘못된 요청입니다."),
+    LOGOUT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "A004", "정상적으로 로그아웃이 수행되지 않았습니다."),
+
 
     //user
     NOT_EXIST_USER(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 사용자입니다."),
@@ -30,7 +32,8 @@ public enum ExceptionEnum {
     NOT_DEV_ENVIRONMENT(HttpStatus.FORBIDDEN, "S002 ", "운영 환경에서 실행할 수 없는 API입니다."),
     WRONG_EXPENSE_COMPARISON_CONDITION(HttpStatus.BAD_REQUEST, "S003",
         "지출 통계 쿼리 파라미터가 잘못 되었습니다."),
-    NOT_EXIST_LAST_WEEK_EXPENSE(HttpStatus.FORBIDDEN, "S004", "유저의 지난 주 같은 요일에 소비 내역이 없습니다. ");
+    NOT_EXIST_LAST_WEEK_EXPENSE(HttpStatus.FORBIDDEN, "S004", "유저의 지난 주 같은 요일에 소비 내역이 없습니다. "),
+    ;
 
 
     private final HttpStatus status;

--- a/src/main/java/com/hyerijang/dailypay/config/SecurityConfiguration.java
+++ b/src/main/java/com/hyerijang/dailypay/config/SecurityConfiguration.java
@@ -21,7 +21,8 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 @EnableMethodSecurity
 public class SecurityConfiguration {
 
-    private static final String[] WHITE_LIST_URL = {"/api/v1/auth/**"};
+    private static final String[] WHITE_LIST_URL = {"/api/v1/auth/**",
+        "/swagger*/**", "/v3/api-docs/**"};
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final AuthenticationProvider authenticationProvider;
     private final LogoutHandler logoutHandler;

--- a/src/main/java/com/hyerijang/dailypay/config/SwaggerOpenAPIConfig.java
+++ b/src/main/java/com/hyerijang/dailypay/config/SwaggerOpenAPIConfig.java
@@ -1,0 +1,36 @@
+package com.hyerijang.dailypay.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * OpenAPI 설정
+ */
+@Configuration
+public class SwaggerOpenAPIConfig {
+
+
+    // API info 등록
+    @Bean
+    public OpenAPI dailyPayAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("Daily Pay API")
+                .description("Daily Pay의 API 명세서입니다.")
+                .version("v1.0.0"));
+    }
+
+    //OpenAPI 그룹 설정
+    @Bean
+    public GroupedOpenApi group1Config() {
+        return GroupedOpenApi.builder()
+            .group("v1-definition")
+            .pathsToMatch("/api/v1/**")
+            .build();
+    }
+
+
+}

--- a/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
+++ b/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
@@ -7,6 +7,8 @@ import com.hyerijang.dailypay.budget.domain.Category;
 import com.hyerijang.dailypay.budget.dto.BudgetDto;
 import com.hyerijang.dailypay.common.aop.ExeTimer;
 import com.hyerijang.dailypay.consulting.service.ConsultingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "consulting", description = "지출 컨설팅 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/consulting")
@@ -33,11 +36,10 @@ public class ConsultingController {
     private static final Long MIN_EXPENSE_OF_A_DAY = 10000L; // 하루 최소 소비 금액
     private final ConsultingService consultingService;
 
-    /**
-     * [D-1] 오늘 지출 추천 API
-     */
+
     @ExeTimer
     @GetMapping("/proposal-info")
+    @Operation(summary = "오늘 지출 추천", description = "오늘 지출 추천")
     public ResponseEntity<Result> getProposalInfo(Authentication authentication) {
         // 1.이번 달 남은 예산 계산
         Long budgetRemainingForThisMonth = consultingService.getBudgetRemainingForThisMonth(
@@ -112,9 +114,9 @@ public class ConsultingController {
         return remainingDays;
     }
 
-    /**
-     * 오늘 지출 안내 API
-     */
+
+    @ExeTimer
+    @Operation(summary = "오늘 지출 안내 ", description = "오늘 지출 안내 ")
     @GetMapping("/today-expenses")
     public ResponseEntity<Result> getTodayExpenses(Authentication authentication) {
 

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -9,6 +9,7 @@ import com.hyerijang.dailypay.expense.dto.GetAllExpenseParam;
 import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
 import com.hyerijang.dailypay.expense.service.ExpenseService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.math.BigDecimal;
 import java.util.List;
@@ -135,15 +136,19 @@ public class ExpenseController {
         return ResponseEntity.notFound().build();
     }
 
-
+    @Schema(description = "지출 응답")
     @Getter
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
     static class Result<T> {
 
+        @Schema(description = "데이터의 개수")
         private Integer count;
+        @Schema(description = "총 지출액")
         private Long totalExpense;
+        @Schema(description = "API 응답 결과를 data에 담아서 반환")
         private T data; // 리스트의 값
+        @Schema(description = "지출 목록 API의 경우 카테고리 별 지출 합계를 포함")
         private Map<Category, BigDecimal> CategoryWiseExpenseSum;
     }
 

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -8,6 +8,8 @@ import com.hyerijang.dailypay.expense.dto.ExpenseDto;
 import com.hyerijang.dailypay.expense.dto.GetAllExpenseParam;
 import com.hyerijang.dailypay.expense.dto.UpdateExpenseRequest;
 import com.hyerijang.dailypay.expense.service.ExpenseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "expenses", description = "지출 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/expenses")
@@ -36,9 +39,8 @@ public class ExpenseController {
 
     private final ExpenseService expenseService;
 
-    /**
-     * 새 지출 내역 (단건) 생성 API <br> 본인의 지출 내역만 생성 가능
-     */
+    @ExeTimer
+    @Operation(summary = "새 지출 내역 (단건) 생성", description = "본인의 지출 내역만 생성 가능")
     @PostMapping
     public ResponseEntity<Result> createExpense(
         @RequestBody CreateExpenseRequest createExpenseRequest, Authentication authentication) {
@@ -48,9 +50,9 @@ public class ExpenseController {
 
     }
 
-    /**
-     * 유저의 지출 내역 (목록) 조회 API br> 본인의 지출 내역만 조회 가능
-     */
+
+    @ExeTimer
+    @Operation(summary = " 유저의 지출 내역 (목록) 조회", description = "본인의 지출 내역만 조회 가능")
     @GetMapping
     public ResponseEntity<Result> getAllExpenses(GetAllExpenseParam getAllExpenseParam,
         Authentication authentication) {
@@ -79,10 +81,9 @@ public class ExpenseController {
                 .CategoryWiseExpenseSum(categoryWiseExpenseSum).build());
     }
 
-    /***
-     * 유저의 지출 내역(단건) 조회 API
-     */
+
     @ExeTimer
+    @Operation(summary = "유저의 지출 내역(단건) 조회", description = "본인의 지출 내역만 조회 가능")
     @GetMapping("/{id}")
     public ResponseEntity<Result> getExpenseById(@PathVariable Long id,
         Authentication authentication) {
@@ -94,10 +95,9 @@ public class ExpenseController {
         }
     }
 
-    /**
-     * 유저의 지출 내역(단건) 수정 API
-     */
+
     @ExeTimer
+    @Operation(summary = "유저의 지출 내역(단건) 수정", description = "본인의 지출 내역만 수정 가능")
     @PatchMapping("/{id}")
     public ResponseEntity<Result> updateExpense(@PathVariable Long id,
         @RequestBody UpdateExpenseRequest updateExpenseRequest, Authentication authentication) {
@@ -109,10 +109,9 @@ public class ExpenseController {
         return ResponseEntity.notFound().build();
     }
 
-    /**
-     * 유저의 지출 내역(단건) 삭제 API
-     */
+
     @ExeTimer
+    @Operation(summary = "유저의 지출 내역(단건) 삭제", description = "본인의 지출 내역만 삭제 가능")
     @DeleteMapping("/{id}")
     public ResponseEntity<Result> deleteExpense(@PathVariable Long id,
         Authentication authentication) {
@@ -124,10 +123,8 @@ public class ExpenseController {
     }
 
 
-    /**
-     * 유저의 지출 내역(단건)을 합계에서 제외하는 API
-     */
     @ExeTimer
+    @Operation(summary = "유저의 지출 내역(단건)을 지출 합계에서 제외", description = "본인의 지출 내역만 제외 가능")
     @PatchMapping("/{id}/exclude-total-sum")
     public ResponseEntity<Result> excludeFromTotal(@PathVariable Long id,
         Authentication authentication) {

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/CreateExpenseRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/CreateExpenseRequest.java
@@ -4,15 +4,25 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hyerijang.dailypay.budget.domain.Category;
 import com.hyerijang.dailypay.expense.domain.Expense;
 import com.hyerijang.dailypay.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
+
+@Schema(description = "지출 생성 요청 DTO")
 public record CreateExpenseRequest
     (
+        @Schema(description = "카테고리")
         Category category,
+        @Schema(description = "지출액")
         Long amount,
+        @Schema(description = "메모")
+
         String memo,
+        @Schema(description = "전체 지출 제외 유무")
+
         Boolean excludeFromTotal,
+        @Schema(description = "지출일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime expenseDate
     ) {

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseParam.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseParam.java
@@ -1,12 +1,15 @@
 package com.hyerijang.dailypay.expense.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.RequestParam;
 
-
+@Schema(description = "지출 내역 목록 조회 조건")
 public record GetAllExpenseParam(
+    @Schema(description = "시작일")
     @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+    @Schema(description = "종료일")
     @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
 
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/UpdateExpenseRequest.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/UpdateExpenseRequest.java
@@ -3,14 +3,25 @@ package com.hyerijang.dailypay.expense.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hyerijang.dailypay.budget.domain.Category;
 import com.hyerijang.dailypay.expense.domain.Expense;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "지출 업데이트 요청")
 public record UpdateExpenseRequest
     (
+        @Schema(description = "카테고리")
         Category category,
+
+        @Schema(description = "지출 금액")
         Long amount,
+
+        @Schema(description = "메모")
         String memo,
+
+        @Schema(description = "전체 지출 제외 유무")
         Boolean excludeFromTotal,
+
+        @Schema(description = "지출일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime expenseDate
     ) {
 

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -6,6 +6,8 @@ import com.hyerijang.dailypay.common.exception.ApiException;
 import com.hyerijang.dailypay.common.exception.response.ExceptionEnum;
 import com.hyerijang.dailypay.statistics.service.StatisticsDummyDataGenerator;
 import com.hyerijang.dailypay.statistics.service.StatisticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Arrays;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "statistics", description = "통계  API")
 @Slf4j
 @RequiredArgsConstructor
 @RestController
@@ -32,9 +35,8 @@ public class StatisticsController {
 
     // === 통계  API === //
 
-    /**
-     * 지난 달 대비 총액 및 카테고리 별 소비율(퍼센티지) 을 반환
-     */
+    @ExeTimer
+    @Operation(summary = "지난 달 대비 이번 달 통계", description = " 지난 달 대비 총액 및 카테고리 별 소비율(퍼센티지) 을 반환")
     @GetMapping
     public ResponseEntity<Result> getExpenseComparison(@Param("condition") String condition,
         Authentication authentication) {
@@ -78,10 +80,8 @@ public class StatisticsController {
 
     // == 더미데이터 생성 == //
 
-    /**
-     * 개발 환경에서만 실행가능한 API, (application-dev.yml)
-     */
     @ExeTimer
+    @Operation(summary = "더미데이터 생성", description = "개발 환경에서만 실행가능한 API, (application-dev.yml)")
     @PostMapping("/dummy-data")
     void generateDummy(Authentication authentication) {
 

--- a/src/main/resources/application-swagger.yaml
+++ b/src/main/resources/application-swagger.yaml
@@ -1,0 +1,21 @@
+# Swagger 관련 Open API 3 설정
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs # API문서를 json 형식으로 보여줌 : http://server:port + path
+    groups:
+      enabled: true
+  
+  paths-to-match: /api/v1/**
+  packages-to-scan: com.hyerijang.dailypay
+  swagger-ui:
+    path: /swagger-ui.html # http://server:port + path를  Swagger UI page(http://server:port/swagger-ui/index.html) 로 리다이렉트 시킴
+    groups-order: ASC #group 정렬 오름차순
+    tags-sorter: alpha        # tag 정렬 알파벳순
+    operations-sorter: alpha    # api 정렬 알파벳순
+    display-request-duration: true
+    doc-expansion: none        # swagger tag 리스트 펼치기
+  cache:
+    disabled: true
+  default-produces-media-type: application/json
+  default-consumes-media-type: application/json

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,4 +6,4 @@ decorator:
 ---
 spring:
   profiles:
-    active: dev, p6spy, security
+    active: dev, p6spy, security, swagger


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

API 문서를 Swagger 문서로 변경하였습니다. 

`@ApiResponse`  (상태 코드 별 설명) 는 다른 리펙토링이 끝난 이후 추가할 예정입니다. 

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 문서 수정


## 📸 스크린샷

![image](https://github.com/hyerijang/daily-pay/assets/46921979/056205f6-759e-4866-8a69-1fc7eedd9c1e)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#55 

