### PR TITLE
fix : swagger API 문서에서 jwt 토큰 사용할 수 있도록 수정

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/budget/controller/BudgetController.java
+++ b/src/main/java/com/hyerijang/dailypay/budget/controller/BudgetController.java
@@ -11,6 +11,7 @@ import com.hyerijang.dailypay.budget.service.BudgetService;
 import com.hyerijang.dailypay.common.aop.ExeTimer;
 import com.hyerijang.dailypay.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.Builder;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "budgets", description = "예산 API")
+@SecurityRequirement(name = "Bearer Authentication")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/budgets")

--- a/src/main/java/com/hyerijang/dailypay/config/SwaggerOpenAPIConfig.java
+++ b/src/main/java/com/hyerijang/dailypay/config/SwaggerOpenAPIConfig.java
@@ -1,5 +1,6 @@
 package com.hyerijang.dailypay.config;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springdoc.core.models.GroupedOpenApi;
@@ -9,10 +10,15 @@ import org.springframework.context.annotation.Configuration;
 /**
  * OpenAPI 설정
  */
+@io.swagger.v3.oas.annotations.security.SecurityScheme(
+    name = "Bearer Authentication",
+    type = SecuritySchemeType.HTTP,
+    bearerFormat = "JWT",
+    scheme = "bearer"
+)
 @Configuration
 public class SwaggerOpenAPIConfig {
-
-
+    
     // API info 등록
     @Bean
     public OpenAPI dailyPayAPI() {

--- a/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
+++ b/src/main/java/com/hyerijang/dailypay/consulting/controller/ConsultingController.java
@@ -10,6 +10,7 @@ import com.hyerijang.dailypay.common.aop.ExeTimer;
 import com.hyerijang.dailypay.consulting.service.ConsultingService;
 import com.hyerijang.dailypay.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "consulting", description = "지출 컨설팅 API")
+@SecurityRequirement(name = "Bearer Authentication")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/consulting")

--- a/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/controller/ExpenseController.java
@@ -12,6 +12,7 @@ import com.hyerijang.dailypay.expense.service.ExpenseService;
 import com.hyerijang.dailypay.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.math.BigDecimal;
 import java.util.List;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "expenses", description = "지출 API")
+@SecurityRequirement(name = "Bearer Authentication")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/expenses")

--- a/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/hyerijang/dailypay/statistics/controller/StatisticsController.java
@@ -9,6 +9,7 @@ import com.hyerijang.dailypay.statistics.service.StatisticsDummyDataGenerator;
 import com.hyerijang.dailypay.statistics.service.StatisticsService;
 import com.hyerijang.dailypay.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Arrays;
 import lombok.Builder;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "statistics", description = "통계  API")
+@SecurityRequirement(name = "Bearer Authentication")
 @Slf4j
 @RequiredArgsConstructor
 @RestController


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

swagger API 문서에서 jwt 토큰을 사용할 수 없어 인증이 필요한 모든 API를 사용할 수 없는 문제가 발생하여 이를 수정했습니다.

## 📋 변경 사항

- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)

## 📸 스크린샷

![image](https://github.com/hyerijang/daily-pay/assets/46921979/d33fab59-3bcb-44c2-8b88-e3b2a5cbaf47)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#55 


