### PR TITLE
feat : 특정 카테고리만 조회 추가

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseSearchCondition.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/ExpenseSearchCondition.java
@@ -1,5 +1,6 @@
 package com.hyerijang.dailypay.expense.dto;
 
+import com.hyerijang.dailypay.budget.domain.Category;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
@@ -7,7 +8,8 @@ import lombok.Builder;
 public record ExpenseSearchCondition(
     LocalDateTime start,
     LocalDateTime end,
-    Long userId
+    Long userId,
+    Category category
 ) {
 
     public static ExpenseSearchCondition of(GetAllExpenseParam getAllExpenseParam, Long userId) {
@@ -15,6 +17,7 @@ public record ExpenseSearchCondition(
             .start(getAllExpenseParam.start().atStartOfDay()) //시작일으리 0시 0분 0초
             .end(getAllExpenseParam.end().atTime(23, 59, 59)) //종료일의 23시 59분 59초
             .userId(userId)
+            .category(getAllExpenseParam.category())
             .build();
     }
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseParam.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/dto/GetAllExpenseParam.java
@@ -1,5 +1,6 @@
 package com.hyerijang.dailypay.expense.dto;
 
+import com.hyerijang.dailypay.budget.domain.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -8,8 +9,18 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Schema(description = "지출 내역 목록 조회 조건")
 public record GetAllExpenseParam(
     @Schema(description = "시작일")
-    @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+    @RequestParam(name = "start")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    LocalDate start,
+    
     @Schema(description = "종료일")
-    @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+    @RequestParam(name = "end")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    LocalDate end,
+
+    @Schema(description = "카테고리")
+    @RequestParam(name = "category")
+    Category category
+) {
 
 }

--- a/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepositoryImpl.java
+++ b/src/main/java/com/hyerijang/dailypay/expense/repository/ExpenseRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.hyerijang.dailypay.expense.repository;
 
 import static com.hyerijang.dailypay.expense.domain.QExpense.expense;
 
+import com.hyerijang.dailypay.budget.domain.Category;
 import com.hyerijang.dailypay.expense.dto.ExpenseDto;
 import com.hyerijang.dailypay.expense.dto.ExpenseSearchCondition;
 import com.querydsl.core.types.Projections;
@@ -30,9 +31,14 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
                 userIdEq(condition.userId()),
                 startAfter(condition.start()),
                 endBefore(condition.end()),
+                categoryEq(condition.category()),
                 isNotDeleted()
             )
             .fetch();
+    }
+
+    private BooleanExpression categoryEq(Category category) {
+        return category != null ? expense.category.eq(category) : null;
     }
 
     private static BooleanExpression userIdEq(Long userId) {


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

특정 카테고리만 조회할 수 있도록 지출 조회 (목록) API에  검색 조건을 추가하였습니다. 

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드 리팩토링


## 📸 스크린샷

![image](https://github.com/hyerijang/daily-pay/assets/46921979/02bc4800-9274-4ed8-8307-316469e7e76a)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#66 #62 #31 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)
