### PR TITLE
fix : v1 이 아닌 다른 버전의 url도 swagger에 포함되도록 수정

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/config/SwaggerOpenAPIConfig.java
+++ b/src/main/java/com/hyerijang/dailypay/config/SwaggerOpenAPIConfig.java
@@ -34,7 +34,7 @@ public class SwaggerOpenAPIConfig {
     public GroupedOpenApi group1Config() {
         return GroupedOpenApi.builder()
             .group("v1-definition")
-            .pathsToMatch("/api/**")
+            .pathsToMatch("/api/**") //
             .build();
     }
 

--- a/src/main/resources/application-swagger.yaml
+++ b/src/main/resources/application-swagger.yaml
@@ -6,7 +6,7 @@ springdoc:
     groups:
       enabled: true
   
-  paths-to-match: /api/v1/**
+  paths-to-match: /api/**
   packages-to-scan: com.hyerijang.dailypay
   swagger-ui:
     path: /swagger-ui.html # http://server:port + path를  Swagger UI page(http://server:port/swagger-ui/index.html) 로 리다이렉트 시킴


### PR DESCRIPTION

## 🚀 풀 리퀘스트 요약

`/api/v3/expenses`, `/api/v3/expenses` 가 swagger api 문서에 포함되지 않고 있었습니다. 

따라서  v1 이 아닌 다른 버전의 url도 swagger에 포함되도록 수정하였습니다. 

## 📋 변경 사항

- [x] 버그 수정

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

- #75


