### PR TITLE
feat : @WithMockUser을 대체할 @WithMockCurrentUser 어노테이션 생성

### DIFF
--- a/src/main/java/com/hyerijang/dailypay/auth/controller/CurrentUserTestController.java
+++ b/src/main/java/com/hyerijang/dailypay/auth/controller/CurrentUserTestController.java
@@ -1,0 +1,30 @@
+package com.hyerijang.dailypay.auth.controller;
+
+import com.hyerijang.dailypay.auth.CurrentUser;
+import com.hyerijang.dailypay.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * {@link com.hyerijang.dailypay.auth.CurrentUser} 테스트를 위한 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/test/currentUser")
+public class CurrentUserTestController {
+
+    @GetMapping
+    public ResponseEntity currentUser(@CurrentUser User user) {
+        return ResponseEntity.ok().body(Result.builder().data(user).build());
+    }
+
+    @Getter
+    @Builder
+    static class Result<T> {
+        private T data; // 리스트의 값
+    }
+
+}

--- a/src/main/java/com/hyerijang/dailypay/auth/dto/UserAdapter.java
+++ b/src/main/java/com/hyerijang/dailypay/auth/dto/UserAdapter.java
@@ -4,6 +4,10 @@ package com.hyerijang.dailypay.auth.dto;
 import com.hyerijang.dailypay.user.domain.User;
 import lombok.Getter;
 
+/**
+ * CurrentUser 어노테이션으로 User 정보를 가져오기 위한 Adapter
+ * @see com.hyerijang.dailypay.auth.CurrentUser
+ */
 @Getter
 public class UserAdapter extends CustomUserDetails {
 

--- a/src/main/java/com/hyerijang/dailypay/config/SwaggerOpenAPIConfig.java
+++ b/src/main/java/com/hyerijang/dailypay/config/SwaggerOpenAPIConfig.java
@@ -34,7 +34,8 @@ public class SwaggerOpenAPIConfig {
     public GroupedOpenApi group1Config() {
         return GroupedOpenApi.builder()
             .group("v1-definition")
-            .pathsToMatch("/api/**") //
+            .pathsToMatch("/api/**")
+            .pathsToExclude("/api/test/**") //test 용 API는 제외
             .build();
     }
 

--- a/src/test/java/com/hyerijang/dailypay/WithMockCurrentUser.java
+++ b/src/test/java/com/hyerijang/dailypay/WithMockCurrentUser.java
@@ -1,0 +1,22 @@
+package com.hyerijang.dailypay;
+
+import com.hyerijang.dailypay.auth.dto.CustomUserDetails;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+/**
+ * {@link WithMockUser} 대신 사용하는 어노테이션 <br/> {@link CustomUserDetails}을 사용하여 user객체를 context에 저장하므로,
+ * 테스트 시 {@link WithMockUser} 사용 불가
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCurrentUser {
+
+    String email() default "dailypay@gmail.com";
+
+    String password() default "password";
+
+    long id() default 12345;
+}

--- a/src/test/java/com/hyerijang/dailypay/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/hyerijang/dailypay/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,43 @@
+package com.hyerijang.dailypay;
+
+import com.hyerijang.dailypay.auth.dto.UserAdapter;
+import com.hyerijang.dailypay.user.domain.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class WithMockCustomUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockCurrentUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCurrentUser annotation) {
+        final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        // @CurrentUser 사용을 위해 UserAdapter를 context에 저장
+        securityContext.setAuthentication(createAuthToken(annotation));
+        return securityContext;
+    }
+
+    private  UsernamePasswordAuthenticationToken createAuthToken(WithMockCurrentUser annotation) {
+        User user = createUser(annotation);
+        UserDetails userDetails = new UserAdapter(user);
+        return new UsernamePasswordAuthenticationToken(
+            userDetails,
+            null,
+            userDetails.getAuthorities()
+        );
+    }
+
+    private  User createUser(WithMockCurrentUser annotation) {
+        User user = User.builder()
+            .email(annotation.email())
+            .password(
+                annotation.password()).build();
+        ReflectionTestUtils.setField(user,"id", annotation.id());
+        return user;
+    }
+
+
+}

--- a/src/test/java/com/hyerijang/dailypay/auth/CurrentUserTestControllerTest.java
+++ b/src/test/java/com/hyerijang/dailypay/auth/CurrentUserTestControllerTest.java
@@ -1,0 +1,52 @@
+package com.hyerijang.dailypay.auth;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.hyerijang.dailypay.WithMockCurrentUser;
+import com.hyerijang.dailypay.auth.controller.CurrentUserTestController;
+import com.hyerijang.dailypay.config.JwtAuthenticationFilter;
+import com.hyerijang.dailypay.config.SecurityConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+@WebMvcTest(
+    value = {CurrentUserTestController.class}, // 특정 Controller만 로딩하여 테스트
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+            classes = {SecurityConfiguration.class, JwtAuthenticationFilter.class}) //스캔 대상에서 제외
+    }
+)
+@AutoConfigureMockMvc //MockMvc를 자동으로 설정 (@Autowired)
+@WithMockCurrentUser
+class CurrentUserTestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void currentUser() throws Exception {
+        //given
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/api/test/currentUser"));
+
+        //than
+        perform.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.data.id").value(12345))
+            .andExpect(jsonPath("$.data.email").value("dailypay@gmail.com"))
+            .andDo(print());
+    }
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

#32 에서 커스텀 객체를 context 에 저장하도록 변경하였기 때문에 테스트 시 @WithMockUser로 authentication 객체 가져올 수 없습니다. 따라서 테스트를 위한 커스텀 객체를 생성합니다. 

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 테스트 추가, 테스트 리팩토링

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

(이 PR과 관련된 이슈가 있다면 이곳에 참조해주세요.)

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)
